### PR TITLE
[RESOLUTION][INT]: support int for cam resolution

### DIFF
--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -290,10 +290,6 @@ private:
    */
   cv::Mat rect_image_;
   /**
-   * @brief Flag to indicate if the bad calibration was reported through events
-   */
-  bool bad_calibration_reported_ = false;
-  /**
    * @brief Rectification maps
    */
   cv::Mat map1_, map2_;
@@ -356,9 +352,6 @@ private:
    * @brief Final publisher for camera info messages
    */
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
-
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr m_bot_status_pub_ptr;
-
 };
 
 } // namespace cv_camera

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -15,7 +15,6 @@
 #include <camera_info_manager/camera_info_manager.hpp>
 #include "std_msgs/msg/u_int8.hpp"
 #include "std_msgs/msg/bool.hpp"
-#include "std_msgs/msg/string.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
 #include "utils/parameters.hpp"
@@ -101,13 +100,6 @@ public:
    * This uses the camera info loaded by loadCameraInfo() and creates a rectified image.
    */
   void rectify();
-
-  /**
-   * @brief Report if the calibration is bad and outputs mostly black images.
-   * 
-   * @param rect_black_px_threshold 
-   */
-  void report_bad_calibration(float rect_black_px_threshold);
 
   /**
    * @brief Open default camera device.

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -246,7 +246,7 @@ private:
    * @brief Sets the exposure of the camera based on the histogram of the image
    * @param frame to set exposure
    */
-  void roi_exposure(cv::Mat& frame);
+  void custom_roi_exposure(cv::Mat& frame);
 
   /**
    * @brief node handle for advertise.

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -15,6 +15,7 @@
 #include <camera_info_manager/camera_info_manager.hpp>
 #include "std_msgs/msg/u_int8.hpp"
 #include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/string.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
 #include "utils/parameters.hpp"
@@ -288,7 +289,10 @@ private:
    * @brief Rectified image
    */
   cv::Mat rect_image_;
-
+  /**
+   * @brief Flag to indicate if the bad calibration was reported through events
+   */
+  bool bad_calibration_reported_ = false;
   /**
    * @brief Rectification maps
    */
@@ -352,6 +356,8 @@ private:
    * @brief Final publisher for camera info messages
    */
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
+
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr m_bot_status_pub_ptr;
 
 };
 

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -102,6 +102,13 @@ public:
   void rectify();
 
   /**
+   * @brief Report if the calibration is bad and outputs mostly black images.
+   * 
+   * @param rect_black_px_threshold 
+   */
+  void report_bad_calibration(float rect_black_px_threshold);
+
+  /**
    * @brief Open default camera device.
    *
    * This opens with device 0.
@@ -277,6 +284,10 @@ private:
    * @brief timestamp of capture image
    */
   rclcpp::Time timestamp_;
+  /**
+   * @brief Rectified image
+   */
+  cv::Mat rect_image_;
 
   /**
    * @brief Rectification maps

--- a/include/cv_camera/driver.h
+++ b/include/cv_camera/driver.h
@@ -173,11 +173,11 @@ class Driver : public rclcpp::Node
   /**
    * @brief Camera cv_cap_prop_frame_width.
    */
-  float width_;
+  int width_;
   /**
    * @brief Camera cv_cap_prop_frame_height.
    */
-  float height_;
+  int height_;
   /**
    * @brief Camera cv_cap_prop_brightness.
    */

--- a/include/cv_camera/driver.h
+++ b/include/cv_camera/driver.h
@@ -132,10 +132,6 @@ class Driver : public rclcpp::Node
   */
   bool always_rectify_;
   /**
-   * @brief Rectified image black pixels threshold. To identify posible bad calibration
-  */
-  float rect_black_px_threshold_;
-  /**
    * @brief Video path
   */
   std::string video_path_;

--- a/include/cv_camera/driver.h
+++ b/include/cv_camera/driver.h
@@ -132,10 +132,13 @@ class Driver : public rclcpp::Node
   */
   bool always_rectify_;
   /**
+   * @brief Rectified image black pixels threshold. To identify posible bad calibration
+  */
+  float rect_black_px_threshold_;
+  /**
    * @brief Video path
   */
   std::string video_path_;
-
   /**
    * @brief Camera info topic
   */

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -340,7 +340,7 @@ void Capture::report_bad_calibration(float rect_black_px_threshold)
     {
       bad_calibration_reported_ = true;
       auto msg = std::make_unique<std_msgs::msg::String>();
-      msg->data = "CAM29";
+      msg->data = "CAM29&" + *node_->get_name();
       m_bot_status_pub_ptr->publish(std::move(msg));
     }
   }

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -26,6 +26,8 @@ Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name
     m_pub_image_ptr = node->create_publisher<sensor_msgs::msg::Image>(img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
     m_pub_rect_image_ptr = node->create_publisher<sensor_msgs::msg::Image>(rect_img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
     m_pub_camera_info_ptr = node->create_publisher<sensor_msgs::msg::CameraInfo>(cam_info_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
+    // Bot Status Event
+    m_bot_status_pub_ptr = node->create_publisher<std_msgs::msg::String>("/bot_status/actions", rclcpp::QoS(1));
     node_->get_parameter_or("capture_delay", dur, dur);
     this->capture_delay_ = rclcpp::Duration(dur, 0.0);
 }
@@ -333,6 +335,14 @@ void Capture::report_bad_calibration(float rect_black_px_threshold)
   {
     RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
                              "[%s] Rect img more than %f pct black. Posible bad calibration for that lens", node_->get_name(), rect_black_px_threshold);
+
+    if (!bad_calibration_reported_)
+    {
+      bad_calibration_reported_ = true;
+      auto msg = std::make_unique<std_msgs::msg::String>();
+      msg->data = "CAM29";
+      m_bot_status_pub_ptr->publish(std::move(msg));
+    }
   }
 }
 

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -206,7 +206,7 @@ bool Capture::capture(bool flip)
   if (flip) cv::flip(bridge_.image, bridge_.image, -1);
 
   // Our custom made exposure set depending on ROI
-  if (roi_exposure_) roi_exposure(bridge_.image);
+  if (roi_exposure_) custom_roi_exposure(bridge_.image);
 
   sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
 
@@ -240,7 +240,7 @@ bool Capture::capture(bool flip)
   return true;
 }
 
-void Capture::roi_exposure(cv::Mat& frame)
+void Capture::custom_roi_exposure(cv::Mat& frame)
 {
   cap_.set(cv::CAP_PROP_AUTO_EXPOSURE, 1);  // disable auto exposure
   double exposure = cap_.get(cv::CAP_PROP_EXPOSURE);

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -340,7 +340,7 @@ void Capture::report_bad_calibration(float rect_black_px_threshold)
     {
       bad_calibration_reported_ = true;
       auto msg = std::make_unique<std_msgs::msg::String>();
-      msg->data = "CAM29&" + *node_->get_name();
+      msg->data = std::string("CAM29&") + node_->get_name();
       m_bot_status_pub_ptr->publish(std::move(msg));
     }
   }

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -358,7 +358,7 @@ bool Capture::setPropertyFromParam(int property_id, const std::string &param_nam
     double value = 0.0;
     if (node_->get_parameter(param_name, value))
     {
-      if (!cap_.set(property_id, static_cast<float>(value)) && value != getProperty(property_id))
+      if (!cap_.set(property_id, value) && value != getProperty(property_id))
       {
         RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(), property_id, value);
         return false;

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -35,6 +35,7 @@ void Capture::loadCameraInfo()
   std::string url;
   if (node_->get_parameter("intrinsic_file", url))
   {
+    if (url == "") return;
     url = "file://" + url;
     if (info_manager_.validateURL(url))
     {

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -358,7 +358,7 @@ bool Capture::setPropertyFromParam(int property_id, const std::string &param_nam
     double value = 0.0;
     if (node_->get_parameter(param_name, value))
     {
-      if (!cap_.set(property_id, value) && value != getProperty(property_id))
+      if (!cap_.set(property_id, static_cast<float>(value)) && value != getProperty(property_id))
       {
         RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(), property_id, value);
         return false;

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -78,7 +78,7 @@ void Capture::loadCameraInfo()
       cv::Mat D = cv::Mat(1, 5, CV_64F, info_.d.data());
       cv::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
   }
-  else if (info_.distortion_model == "equidistant")
+  else if (info_.distortion_model == "equidistant" || info_.distortion_model == "fisheye")
   {
       cv::Mat D = cv::Mat(1, 4, CV_64F, info_.d.data());
       cv::fisheye::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -42,7 +42,6 @@ void Driver::parameters_setup()
   param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
   param_manager_.addParameter(rectify_, "rectify", false);
   param_manager_.addParameter(always_rectify_, "always_rectify", false);
-  param_manager_.addParameter(rect_black_px_threshold_, "rect_black_px_threshold", 0.5f);
   param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
   param_manager_.addParameter<std::string>(video_path_, "video_path", "");
   param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
@@ -257,7 +256,6 @@ void Driver::proceed()
       if (always_rectify_ || (rectify_ && undistort_img_req_bool_))
       {
         camera_->rectify();
-        camera_->report_bad_calibration(rect_black_px_threshold_);
       }
     }
   }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -254,9 +254,7 @@ void Driver::proceed()
     else
     {
       if (always_rectify_ || (rectify_ && undistort_img_req_bool_))
-      {
         camera_->rectify();
-      }
     }
   }
 }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -42,6 +42,7 @@ void Driver::parameters_setup()
   param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
   param_manager_.addParameter(rectify_, "rectify", false);
   param_manager_.addParameter(always_rectify_, "always_rectify", false);
+  param_manager_.addParameter(rect_black_px_threshold_, "rect_black_px_threshold", 0.5f);
   param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
   param_manager_.addParameter<std::string>(video_path_, "video_path", "");
   param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
@@ -250,7 +251,10 @@ void Driver::proceed()
     else
     {
       if (always_rectify_ || (rectify_ && undistort_img_req_bool_))
+      {
         camera_->rectify();
+        camera_->report_bad_calibration(rect_black_px_threshold_);
+      }
     }
   }
 }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -52,6 +52,10 @@ void Driver::parameters_setup()
   // Video capture parameters
   param_manager_.addParameter(width_, "width", 640);
   param_manager_.addParameter(height_, "height", 360);
+  this->declare_parameter("cv_cap_prop_frame_width", 640.0);
+  this->declare_parameter("cv_cap_prop_frame_height", 360.0);
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
   param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
   param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
   param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
@@ -114,8 +118,8 @@ bool Driver::setup()
 
   camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
   camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "width");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "height");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
   camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
   camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
   camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
@@ -288,10 +292,10 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
         publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
                                                std::bind(&Driver::proceed, this));
       }
-      else if (name == "width" || name == "height")
+      else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
       {
-        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "width");
-        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "height");
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
       }
       else if (name == "cv_cap_prop_brightness")
       {
@@ -324,6 +328,21 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
       else if (name == "cv_cap_prop_auto_exposure")
       {
         camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
+      }
+    }
+    else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
+    {
+      if (name == "width")
+      {
+        width_ = parameter.as_int();
+        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+      }
+      else if (name == "height")
+      {
+        height_ = parameter.as_int();
+        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
       }
     }
     else if (type == rclcpp::ParameterType::PARAMETER_STRING)

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -50,8 +50,8 @@ void Driver::parameters_setup()
   param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
 
   // Video capture parameters
-  param_manager_.addParameter(width_, "width", 640.0f);
-  param_manager_.addParameter(height_, "height", 360.0f);
+  param_manager_.addParameter(width_, "width", 640);
+  param_manager_.addParameter(height_, "height", 360);
   param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
   param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
   param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);


### PR DESCRIPTION
---
**Basic Info**

Main Objective of this PR: Enable cam to support int for resolution configuration
Issue this PR addresses: N/A
Kiwibot fleet tested on: Dev4_x
PR submission date: Done testing

---
**Description of contribution in a few bullet points**

* Enable cam to support int for resolution configuration
* opencv only accepts double parameters, but it was confusing as realsense parameters were int. So know both are set with the same type.

---
**PR testing**

- [x] Already tested and approved in this Kronos PR: https://github.com/kiwicampus/Kronos-Project/pull/2557 
