### PR TITLE
FEAT: update cam info and rescale intrinsics

### DIFF
--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -222,12 +222,17 @@ public:
    */
   void set_error_image(const std::string& error_msg, int width = 640, int height = 360);
 
-private:
   /**
    * @brief rescale camera calibration to another resolution
    */
   void rescaleCameraInfo(uint width, uint height);
 
+  /**
+   * @brief initialize undistort rectify map
+   */
+  void initUndistortRectifyMap();
+
+private:
   /**
    * @brief Select appropiate encoding for the image
    */

--- a/include/cv_camera/driver.h
+++ b/include/cv_camera/driver.h
@@ -252,6 +252,10 @@ class Driver : public rclcpp::Node
    */
   int height_;
   /**
+   * @brief Camera aspect ratio.
+   */
+  float aspect_ratio_;
+  /**
    * @brief Camera cv_cap_prop_brightness.
    */
   float cv_cap_prop_brightness_;

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -68,26 +68,7 @@ void Capture::loadCameraInfo()
       return;
   }
 
-  cv::Mat K = cv::Mat(3, 3, CV_64F, info_.k.data());
-  cv::Mat R = cv::Mat(3, 3, CV_64F, info_.r.data());
-  cv::Mat P = cv::Mat(3, 4, CV_64F, info_.p.data());
-
-  // select depending on distortion model
-  if (info_.distortion_model == "plumb_bob")
-  {
-      cv::Mat D = cv::Mat(1, 5, CV_64F, info_.d.data());
-      cv::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
-  }
-  else if (info_.distortion_model == "equidistant" || info_.distortion_model == "fisheye")
-  {
-      cv::Mat D = cv::Mat(1, 4, CV_64F, info_.d.data());
-      cv::fisheye::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
-  }
-  else
-  {
-      RCLCPP_ERROR(node_->get_logger(), "[%s] Unsupported distortion model: %s", node_->get_name(), info_.distortion_model.c_str());
-      return;
-  }
+  initUndistortRectifyMap();
 
   rescale_camera_info_ = false;
   node_->get_parameter_or("rescale_camera_info", rescale_camera_info_, rescale_camera_info_);
@@ -114,8 +95,42 @@ void Capture::loadCameraInfo()
   }
 }
 
+void Capture::initUndistortRectifyMap()
+{
+
+  cv::Mat K = cv::Mat(3, 3, CV_64F, info_.k.data());
+  cv::Mat R = cv::Mat(3, 3, CV_64F, info_.r.data());
+  cv::Mat P = cv::Mat(3, 4, CV_64F, info_.p.data());
+
+  // select depending on distortion model
+  if (info_.distortion_model == "plumb_bob")
+  {
+      cv::Mat D = cv::Mat(1, 5, CV_64F, info_.d.data());
+      cv::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
+  }
+  else if (info_.distortion_model == "equidistant" || info_.distortion_model == "fisheye")
+  {
+      cv::Mat D = cv::Mat(1, 4, CV_64F, info_.d.data());
+      cv::fisheye::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
+  }
+  else
+  {
+      RCLCPP_ERROR(node_->get_logger(), "[%s] Unsupported distortion model: %s", node_->get_name(), info_.distortion_model.c_str());
+      return;
+  }
+}
+
 void Capture::rescaleCameraInfo(uint width, uint height)
 {
+  if (info_.width == width && info_.height == height)
+  {
+    RCLCPP_INFO(node_->get_logger(), "[%s] No rescaling needed", node_->get_name());
+    return;
+  }
+
+  RCLCPP_WARN(node_->get_logger(), "[%s] Rescaling camera parameters from %dx%d to %dx%d", 
+              node_->get_name(), info_.width, info_.height, width, height);
+
   double width_coeff = static_cast<double>(width) / info_.width;
   double height_coeff = static_cast<double>(height) / info_.height;
   info_.width = width;
@@ -131,6 +146,8 @@ void Capture::rescaleCameraInfo(uint width, uint height)
   info_.p[2] *= width_coeff;
   info_.p[5] *= height_coeff;
   info_.p[6] *= height_coeff;
+
+  initUndistortRectifyMap();
 }
 
 bool Capture::open(int32_t device_id)
@@ -234,8 +251,6 @@ bool Capture::capture(bool flip)
   // Fill the cam info message.
   info_.header.stamp = timestamp_;
   info_.header.frame_id = frame_id_;
-  info_.width = bridge_.image.cols;
-  info_.height = bridge_.image.rows;
 
   m_pub_camera_info_ptr->publish(info_);
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -172,6 +172,7 @@ bool Driver::setup()
   camera_->set_error_image(error_msg.str());
 
   // Log camera starting configuration
+  aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
   RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
               name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
               int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_), int(camera_->getProperty(cv::CAP_PROP_FPS)),
@@ -370,22 +371,20 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
     {
       if (name == "width")
       {
-        RCLCPP_INFO(get_logger(), "Setting new width to %ld", parameter.as_int());
         width_ = parameter.as_int();
-        if (width_ == 1920) height_ = 1080;
-        if (width_ == 1280) height_ = 720;
-        if (width_ == 640) height_ = 360;
+        // update height to maintain aspect ratio
+        height_ = int(width_ / aspect_ratio_);
+        RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio", parameter.as_int(), height_);
         // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
         // so we need to reset the timer to update the resolution
         update_resolution_tmr_->reset();
       }
       else if (name == "height")
       {
-        RCLCPP_INFO(get_logger(), "Setting new height to %ld", parameter.as_int());
         height_ = parameter.as_int();
-        if (height_ == 1080) width_ = 1920;
-        if (height_ == 720) width_ = 1280;
-        if (height_ == 360 || height_ == 480) width_ = 640;
+        // update width to maintain aspect ratio
+        width_ = int(height_ * aspect_ratio_);
+        RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio", parameter.as_int(), width_);
         // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
         // so we need to reset the timer to update the resolution
         update_resolution_tmr_->reset();
@@ -438,10 +437,12 @@ void Driver::update_resolution()
   if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH))
   {
     this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+    camera_->rescaleCameraInfo(width_, height_);
   }
   if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT))
   {
     this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+    camera_->rescaleCameraInfo(width_, height_);
   }
 }
 


### PR DESCRIPTION
- Setting only the width parameter does nothing. We must set the width and height parameters only after the other
- Changing aspect ratio must not be allowed as rescaling parameter logic will fail