### PR TITLE
Add feature to check camera focus using Laplace variance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,83 @@ Nodelet
 
 This node works as nodelet (`cv_camera/CvCameraNodelet`).
 
-Contributors
+### Using the Launch File
+
+The `kiwi_runtime_load.launch.py` file is used to launch the camera node with specific configurations. It supports both standalone node execution and composition in a container.
+
+#### Launch Arguments
+
+- `cam_name`: The name of the camera to be used. Default is `"unknown"`.
+- `cam_port`: The port to which the camera is connected. Default is `"unknown"`.
+- `intrinsic_file`: The path to the camera's intrinsic calibration file. Default is `"unknown"`.
+- `params_file`: The path to the parameters file. Default is `"vision_params.yaml"`.
+
+##### cam_port Format
+
+The `cam_port` parameter uses a specific format to represent the USB port path:
+
+- The format is `"bus-port_path:interface"`.
+- To determine the correct value for your system:
+  1. Use the `lsusb` command to list all connected USB devices.
+  2. Identify the Bus and Device numbers for your camera.
+  3. Use `udevadm` to find the detailed path of the device.
+     ```bash
+     udevadm info --query=path --name=/dev/bus/usb/<Bus>/<Device>
+     ```
+     Replace `<Bus>` and `<Device>` with the numbers from your `lsusb` output.
+  4. The output will include a path like `/devices/.../usb3/3-4/3-4.4/3-4.4.4`.
+  5. Use the bus number and the hierarchical path to construct the `cam_port` entry.
+     Example: If the path is `3-4.4.4` and the bus is `3`, the entry is `"3-4.4.4:1.0"`.
+
+#### How to Launch
+
+To launch the camera node, use the following command:
+
+```bash
+ros2 launch cv_camera kiwi_runtime_load.launch.py \
+    cam_name:=<camera_name> \
+    cam_port:=<camera_port> \
+    intrinsic_file:=<path_to_intrinsic_file> \
+    params_file:=<path_to_params_file>
+```
+
+Replace `<camera_name>`, `<cam_port>`, `<path_to_intrinsic_file>`, and `<path_to_params_file>` with the appropriate values for your setup.
+
+#### Example
+
+Here is an example command with real values:
+
+```bash
+ros2 launch cv_camera kiwi_runtime_load.launch.py \
+    cam_name:=front_camera \
+    cam_port:=3-4.4.4:1.0 \
+    intrinsic_file:=front_camera_intrinsics.yaml \
+    params_file:=front_camera_params.yaml
+```
+
+### Using the Kiwi Launch File
+
+The `kiwi.launch.py` file is designed to launch multiple camera nodes using predefined device IDs and configuration files.
+
+#### Launch Arguments
+
+- `camera_info_url`: Path to the camera info file. Defaults to the intrinsic calibration file in the `vision_bringup` package.
+- `params_file`: Path to the parameters file. Defaults to the `vision_params.yaml` in the `vision_bringup` package.
+
+#### How to Launch
+
+To launch the camera nodes, use the following command:
+
+```bash
+ros2 launch cv_camera kiwi.launch.py \
+    camera_info_url:=<path_to_camera_info_file> \
+    params_file:=<path_to_params_file>
+```
+
+Replace `<path_to_camera_info_file>` and `<path_to_params_file>` with the appropriate paths if you wish to override the defaults.
+
+About
 --------------------
 
-PR is welcome. I'll review your code to keep consistency, be patient.
+This package is a fork of the [original cv_camera package](https://github.com/OTL/cv_camera) created by Takashi Ogura (OTL).
 
-* Oleg Kalachev
-* Mikael Arguedas
-* Maurice Meedendorp
-* Max Schettler
-* Lukas Bulwahn

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -232,8 +232,25 @@ public:
    * @brief initialize undistort rectify map
    */
   void initUndistortRectifyMap();
+  /**
+   * @brief Check if the image is empty
+   * @return True if image is empty, false otherwise
+   */
+  bool is_empty();  
+  /**
+   * @brief Check if the image is focused
+   * @return True if image is focused, false otherwise
+   */
+  bool isFocused();
 
 private:
+  
+  /**
+  * @brief Get Laplacian variance of last captured image
+  * @return Laplacian variance value
+  */
+  double getLaplacianVariance();
+
   /**
    * @brief Select appropiate encoding for the image
    */

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -58,6 +58,7 @@ public:
           const std::string &rect_image_topic_name,
           const std::string &frame_id,
           const bool roi_exposure,
+          const double focus_threshold,
           uint32_t buffer_size);
 
   /**
@@ -373,19 +374,6 @@ private:
    */
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
 
-  // Parameters Handling
-  NodeParamManager param_manager_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr params_callback_handle_;
-  /**
-   * @brief Callback executed when a parameter change is detected
-   * @param parameters list of parameters changed
-   */
-  rcl_interfaces::msg::SetParametersResult parameters_cb(const std::vector<rclcpp::Parameter>& parameters);
-  
-  /**
-   * @brief Parameter manager variables initialization
-   */
-  void param_manager_setup();
 };
 
 } // namespace cv_camera

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -230,7 +230,7 @@ class Capture
 
    private:
     /**
-     * @brief Get Laplacian variance of the image
+     * @brief Get Laplacian variance of last captured image
      * @return Laplacian variance value
      */
     double getLaplacianVariance();

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -3,21 +3,21 @@
 #ifndef CV_CAMERA_CAPTURE_H
 #define CV_CAMERA_CAPTURE_H
 
-#include "cv_camera/exception.h"
 #include <string>
+#include "cv_camera/exception.h"
 
-#include <rclcpp/rclcpp.hpp>
+#include <camera_info_manager/camera_info_manager.hpp>
 #include <cv_bridge/cv_bridge.hpp>
 #include <image_transport/image_transport.hpp>
-#include <sensor_msgs/msg/camera_info.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/image_encodings.hpp>
-#include "opencv2/opencv.hpp"
-#include <camera_info_manager/camera_info_manager.hpp>
-#include "std_msgs/msg/u_int8.hpp"
-#include "std_msgs/msg/bool.hpp"
-#include "std_srvs/srv/trigger.hpp"
-#include "std_srvs/srv/set_bool.hpp"
+#include <sensor_msgs/msg/camera_info.hpp>
 #include "cv_camera/srv/grab_frame.hpp"
+#include "opencv2/opencv.hpp"
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/u_int8.hpp"
+#include "std_srvs/srv/set_bool.hpp"
+#include "std_srvs/srv/trigger.hpp"
 
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
@@ -33,8 +33,7 @@ using std::placeholders::_3;
 /**
  * @brief namespace of this package
  */
-namespace cv_camera
-{
+namespace cv_camera {
 
 /**
  * @brief captures by cv::VideoCapture and publishes to ROS topic.
@@ -42,319 +41,321 @@ namespace cv_camera
  */
 class Capture
 {
-public:
-  /**
-   * @brief costruct with ros node and topic settings
-   *
-   * @param node ROS node handle for advertise topic.
-   * @param img_topic_name name of topic to publish (this may be image_raw).
-   * @param cam_info_topic_name name of topic to publish cam info (this may be camera_info).
-   * @param buffer_size size of publisher buffer.
-   * @param frame_id frame_id of publishing messages.
-   */
-  Capture(rclcpp::Node::SharedPtr node,
-          const std::string &img_topic_name,
-          const std::string &cam_info_topic_name,
-          const std::string &rect_image_topic_name,
-          const std::string &frame_id,
-          const bool roi_exposure,
-          uint32_t buffer_size);
+   public:
+    /**
+     * @brief costruct with ros node and topic settings
+     *
+     * @param node ROS node handle for advertise topic.
+     * @param img_topic_name name of topic to publish (this may be image_raw).
+     * @param cam_info_topic_name name of topic to publish cam info (this may be camera_info).
+     * @param buffer_size size of publisher buffer.
+     * @param frame_id frame_id of publishing messages.
+     */
+    Capture(rclcpp::Node::SharedPtr node, const std::string& img_topic_name, const std::string& cam_info_topic_name,
+            const std::string& rect_image_topic_name, const std::string& frame_id, const bool roi_exposure,
+            uint32_t buffer_size);
 
-  /**
-   * @brief Open capture device with device ID.
-   *
-   * @param device_id id of camera device (number from 0)
-   * @throw cv_camera::DeviceError device open failed
-   *
-   */
-  bool open(int32_t device_id);
+    /**
+     * @brief Open capture device with device ID.
+     *
+     * @param device_id id of camera device (number from 0)
+     * @throw cv_camera::DeviceError device open failed
+     *
+     */
+    bool open(int32_t device_id);
 
-  /**
-   * @brief Open capture device with device name.
-   *
-   * @param port path of the camera device
-   * @throw cv_camera::DeviceError device open failed
-   */
-  bool open(const std::string &port);
+    /**
+     * @brief Open capture device with device name.
+     *
+     * @param port path of the camera device
+     * @throw cv_camera::DeviceError device open failed
+     */
+    bool open(const std::string& port);
 
-  /**
-   * @brief Finds the equivalent camera device associated to
-   *        one port.
-   * @param command Terminal command to be executed
-   * @return command_output::Command output delivered by the terminal
-   */
-  std::string execute_command(const char* command);
+    /**
+     * @brief Finds the equivalent camera device associated to
+     *        one port.
+     * @param command Terminal command to be executed
+     * @return command_output::Command output delivered by the terminal
+     */
+    std::string execute_command(const char* command);
+
+    /**
+     * @brief Finds the equivalent camera device associated to
+     *        one port.
+     * @param port Port number of interest
+     * @return port::DeviceError device open failed
+     */
+    std::string det_device_path(const char* port);
+
+    /**
+     * @brief Load camera info from file.
+     *
+     * This loads the camera info from the file specified in the camera_info_url parameter.
+     */
+    void loadCameraInfo();
+
+    /**
+     * @brief Rectify image using camera info.
+     *
+     * This uses the camera info loaded by loadCameraInfo() and creates a rectified image.
+     */
+    void rectify();
+
+    /**
+     * @brief Open default camera device.
+     *
+     * This opens with device 0.
+     *
+     * @throw cv_camera::DeviceError device open failed
+     */
+    void open();
+
+    /**
+     * @brief open video file instead of capture device.
+     */
+    bool openFile(const std::string& file_path);
+
+    /**
+     * @brief Close capture device.
+     * Uses release OpenCV function.
+     */
+    void close();
+
+    /**
+     * @brief Checks if capture device is opened
+     * Uses release OpenCV function.
+     */
+    bool is_opened();
+
+    /**
+     * @brief capture an image and store.
+     * to publish the captured image, call publish();
+     * @param flip_vertical flip the image around vertical axis if true
+     * @param flip_horizontal flip the image around horizontal axis if true
+     * @return true if success to capture, false if not captured.
+     */
+    bool capture(bool flip_vertical, bool flip_horizontal);
+
+    /**
+     * @brief pull an image from the camera but dont decode it
+     *
+     * @return true if success to pull, false if not pulled.
+     */
+    bool grab();
+
+    /**
+     * @brief Publish the image that is already captured by capture().
+     *
+     */
+    void publish(sensor_msgs::msg::Image::UniquePtr msg);
+
+    /**
+     * @brief accessor of CameraInfo.
+     *
+     * you have to call capture() before call this.
+     *
+     * @return CameraInfo
+     */
+    inline const sensor_msgs::msg::CameraInfo& getInfo() const { return info_; }
+
+    /**
+     * @brief accessor of cv::Mat
+     *
+     * you have to call capture() before call this.
+     *
+     * @return captured cv::Mat
+     */
+    inline const cv::Mat& getCvImage() const { return bridge_.image; }
+
+    /**
+     * @brief accessor of ROS Image message.
+     *
+     * you have to call capture() before call this.
+     *
+     * @return message pointer.
+     */
+    sensor_msgs::msg::Image::SharedPtr getImageMsgPtr();
+
+    /**
+     * @brief try capture image width
+     * @return true if success
+     */
+    inline bool setWidth(int32_t width) { return cap_.set(cv::CAP_PROP_FRAME_WIDTH, width); }
+
+    /**
+     * @brief try capture image height
+     * @return true if success
+     */
+    inline bool setHeight(int32_t height) { return cap_.set(cv::CAP_PROP_FRAME_HEIGHT, height); }
+
+    /**
+     * @brief set CV_PROP_*
+     * @return true if success
+     */
+    bool setPropertyFromParam(int property_id, const std::string& param_name);
+
+    /**
+     * @brief get CV_PROP_*
+     * @return value of property
+     */
+    double getProperty(int property_id);
+
+    /**
+     * @brief Set black error image in case of error.
+     */
+    void set_error_image(const std::string& error_msg, int width = 640, int height = 360);
+
+    /**
+     * @brief rescale camera calibration to another resolution
+     */
+    void rescaleCameraInfo(uint width, uint height);
+
+    /**
+     * @brief initialize undistort rectify map
+     */
+    void initUndistortRectifyMap();
   
-  /**
-   * @brief Finds the equivalent camera device associated to
-   *        one port.
-   * @param port Port number of interest
-   * @return port::DeviceError device open failed
-   */
-  std::string det_device_path(const char* port);
-  
-  /**
-   * @brief Load camera info from file.
-   *
-   * This loads the camera info from the file specified in the camera_info_url parameter.
-   */
-  void loadCameraInfo();
+    /**
+     * @brief Check if the image is empty
+     * @return True if image is empty, false otherwise
+     */
+    bool is_empty();
 
-  /**
-   * @brief Rectify image using camera info.
-   *
-   * This uses the camera info loaded by loadCameraInfo() and creates a rectified image.
-   */
-  void rectify();
+    /**
+     * @brief Check if the image is focused
+     * @return True if image is focused, false otherwise
+     */
+    bool isFocused();
 
-  /**
-   * @brief Open default camera device.
-   *
-   * This opens with device 0.
-   *
-   * @throw cv_camera::DeviceError device open failed
-   */
-  void open();
+   private:
+    /**
+     * @brief Get Laplacian variance of the image
+     * @return Laplacian variance value
+     */
+    double getLaplacianVariance();
 
-  /**
-   * @brief open video file instead of capture device.
-   */
-  bool openFile(const std::string &file_path);
+    /**
+     * @brief Select appropiate encoding for the image
+     */
+    std::string mat_type2encoding(int mat_type);
 
-  /**
-   * @brief Close capture device.
-   * Uses release OpenCV function.
-  */
-  void close();
+    /**
+     * @brief set current time to message header
+     */
+    void set_now(builtin_interfaces::msg::Time& time);
 
-  /**
-   * @brief Checks if capture device is opened
-   * Uses release OpenCV function.
-  */
-  bool is_opened();
+    /**
+     * @brief Sets the exposure of the camera based on the histogram of the image
+     * @param frame to set exposure
+     */
+    void custom_roi_exposure(cv::Mat& frame);
 
-  /**
-   * @brief capture an image and store.
-   * to publish the captured image, call publish();
-   * @param flip_vertical flip the image around vertical axis if true
-   * @param flip_horizontal flip the image around horizontal axis if true
-   * @return true if success to capture, false if not captured.
-   */
-  bool capture(bool flip_vertical, bool flip_horizontal);
+    /**
+     * @brief node handle for advertise.
+     */
+    rclcpp::Node::SharedPtr node_;
 
-  /**
-   * @brief pull an image from the camera but dont decode it
-   *
-   * @return true if success to pull, false if not pulled.
-   */
-  bool grab();
+    /**
+     * @brief ROS image transport utility.
+     */
+    image_transport::ImageTransport it_;
 
-  /**
-   * @brief Publish the image that is already captured by capture().
-   *
-   */
-  void publish(sensor_msgs::msg::Image::UniquePtr msg);
+    /**
+     * @brief name of topic without namespace (usually "image_raw").
+     */
+    std::string img_topic_name_;
 
-  /**
-   * @brief accessor of CameraInfo.
-   *
-   * you have to call capture() before call this.
-   *
-   * @return CameraInfo
-   */
-  inline const sensor_msgs::msg::CameraInfo &getInfo() const
-  {
-    return info_;
-  }
+    /**
+     * @brief name of topic without namespace (usually "camera_info").
+     */
+    std::string cam_info_topic_name_;
 
-  /**
-   * @brief accessor of cv::Mat
-   *
-   * you have to call capture() before call this.
-   *
-   * @return captured cv::Mat
-   */
-  inline const cv::Mat &getCvImage() const
-  {
-    return bridge_.image;
-  }
+    /**
+     * @brief name of rectified topic without namespace (usually "image_rect").
+     */
+    std::string rect_img_topic_name_;
+    /**
+     * @brief header.frame_id for publishing images.
+     */
+    std::string frame_id_;
+    /**
+     * @brief Enables/Disables out custom exposure controller depending on histogram
+     */
+    bool roi_exposure_;
+    /**
+     * @brief timestamp of capture image
+     */
+    rclcpp::Time timestamp_;
+    /**
+     * @brief Rectified image
+     */
+    cv::Mat rect_image_;
+    /**
+     * @brief Rectification maps
+     */
+    cv::Mat map1_, map2_;
+    /**
+     * @brief size of publisher buffer
+     */
+    uint32_t buffer_size_;
 
-  /**
-   * @brief accessor of ROS Image message.
-   *
-   * you have to call capture() before call this.
-   *
-   * @return message pointer.
-   */
-  sensor_msgs::msg::Image::SharedPtr getImageMsgPtr();
+    /**
+     * @brief image publisher created by image_transport::ImageTransport.
+     */
+    image_transport::CameraPublisher pub_;
 
-  /**
-   * @brief try capture image width
-   * @return true if success
-   */
-  inline bool setWidth(int32_t width)
-  {
-    return cap_.set(cv::CAP_PROP_FRAME_WIDTH, width);
-  }
+    /**
+     * @brief video path to be streamed
+     */
+    std::string video_path_ = "";
 
-  /**
-   * @brief try capture image height
-   * @return true if success
-   */
-  inline bool setHeight(int32_t height)
-  {
-    return cap_.set(cv::CAP_PROP_FRAME_HEIGHT, height);
-  }
+    /**
+     * @brief capture device.
+     */
+    cv::VideoCapture cap_;
 
-  /**
-   * @brief set CV_PROP_*
-   * @return true if success
-   */
-  bool setPropertyFromParam(int property_id, const std::string &param_name);
+    /**
+     * @brief this stores last captured image.
+     */
+    cv_bridge::CvImage bridge_;
 
-  /**
-   * @brief get CV_PROP_*
-   * @return value of property
-   */
-  double getProperty(int property_id);
+    /**
+     * @brief this stores last captured image info.
+     *
+     * currently this has image size (width/height) only.
+     */
+    sensor_msgs::msg::CameraInfo info_;
 
-  /**
-   * @brief Set black error image in case of error.
-   */
-  void set_error_image(const std::string& error_msg, int width = 640, int height = 360);
+    /**
+     * @brief camera info manager
+     */
+    camera_info_manager::CameraInfoManager info_manager_;
 
-  /**
-   * @brief rescale camera calibration to another resolution
-   */
-  void rescaleCameraInfo(uint width, uint height);
+    /**
+     * @brief rescale_camera_info param value
+     */
+    bool rescale_camera_info_;
 
-  /**
-   * @brief initialize undistort rectify map
-   */
-  void initUndistortRectifyMap();
+    /**
+     * @brief capture_delay param value
+     */
+    rclcpp::Duration capture_delay_;
 
-private:
-  /**
-   * @brief Select appropiate encoding for the image
-   */
-  std::string mat_type2encoding(int mat_type);
-
-  /**
-   * @brief set current time to message header
-   */
-  void set_now(builtin_interfaces::msg::Time& time);
-
-  /**
-   * @brief Sets the exposure of the camera based on the histogram of the image
-   * @param frame to set exposure
-   */
-  void custom_roi_exposure(cv::Mat& frame);
-
-  /**
-   * @brief node handle for advertise.
-   */
-  rclcpp::Node::SharedPtr node_;
-
-  /**
-   * @brief ROS image transport utility.
-   */
-  image_transport::ImageTransport it_;
-
-  /**
-   * @brief name of topic without namespace (usually "image_raw").
-   */
-  std::string img_topic_name_;
-
-  /**
-   * @brief name of topic without namespace (usually "camera_info").
-   */
-  std::string cam_info_topic_name_;
-
-  /**
-   * @brief name of rectified topic without namespace (usually "image_rect").
-   */
-  std::string rect_img_topic_name_;
-  /**
-   * @brief header.frame_id for publishing images.
-   */
-  std::string frame_id_;
-  /**
-   * @brief Enables/Disables out custom exposure controller depending on histogram
-   */
-  bool roi_exposure_;
-  /**
-   * @brief timestamp of capture image
-   */
-  rclcpp::Time timestamp_;
-  /**
-   * @brief Rectified image
-   */
-  cv::Mat rect_image_;
-  /**
-   * @brief Rectification maps
-   */
-  cv::Mat map1_, map2_;
-  /**
-   * @brief size of publisher buffer
-   */
-  uint32_t buffer_size_;
-
-  /**
-   * @brief image publisher created by image_transport::ImageTransport.
-   */
-  image_transport::CameraPublisher pub_;
-
-  /**
-   * @brief video path to be streamed
-   */
-  std::string video_path_ = "";
-
-  /**
-   * @brief capture device.
-   */
-  cv::VideoCapture cap_;
-
-  /**
-   * @brief this stores last captured image.
-   */
-  cv_bridge::CvImage bridge_;
-
-  /**
-   * @brief this stores last captured image info.
-   *
-   * currently this has image size (width/height) only.
-   */
-  sensor_msgs::msg::CameraInfo info_;
-
-  /**
-   * @brief camera info manager
-   */
-  camera_info_manager::CameraInfoManager info_manager_;
-
-  /**
-   * @brief rescale_camera_info param value
-   */
-  bool rescale_camera_info_;
-
-  /**
-   * @brief capture_delay param value
-   */
-  rclcpp::Duration capture_delay_;
-
-  /**
-   * @brief Final publisher for image messages
-   */
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_image_ptr;
-  /**
-   * @brief Final publisher for rectified image messages
-   */
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_rect_image_ptr;
-  /**
-   * @brief Final publisher for camera info messages
-   */
-  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
+    /**
+     * @brief Final publisher for image messages
+     */
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_image_ptr;
+    /**
+     * @brief Final publisher for rectified image messages
+     */
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_rect_image_ptr;
+    /**
+     * @brief Final publisher for camera info messages
+     */
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
 };
 
-} // namespace cv_camera
+}  // namespace cv_camera
 
-#endif // CV_CAMERA_CAPTURE_H
+#endif  // CV_CAMERA_CAPTURE_H

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -385,7 +385,7 @@ private:
   /**
    * @brief Parameter manager variables initialization
    */
-  void Capture::param_manager_setup();
+  void param_manager_setup();
 };
 
 } // namespace cv_camera

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -244,7 +244,9 @@ public:
   bool isFocused();
 
 private:
-  
+
+  // Parameters
+  double focus_threshold_;
   /**
   * @brief Get Laplacian variance of last captured image
   * @return Laplacian variance value
@@ -370,6 +372,20 @@ private:
    * @brief Final publisher for camera info messages
    */
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
+
+  // Parameters Handling
+  NodeParamManager param_manager_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr params_callback_handle_;
+  /**
+   * @brief Callback executed when a parameter change is detected
+   * @param parameters list of parameters changed
+   */
+  rcl_interfaces::msg::SetParametersResult parameters_cb(const std::vector<rclcpp::Parameter>& parameters);
+  
+  /**
+   * @brief Parameter manager variables initialization
+   */
+  void Capture::param_manager_setup();
 };
 
 } // namespace cv_camera

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -58,7 +58,7 @@ public:
           const std::string &rect_image_topic_name,
           const std::string &frame_id,
           const bool roi_exposure,
-          const double focus_threshold,
+          double focus_threshold,
           uint32_t buffer_size);
 
   /**
@@ -218,6 +218,12 @@ public:
    * @return value of property
    */
   double getProperty(int property_id);
+
+  /**
+   * @brief Set focus threshold
+   * @param focus_threshold focus threshold
+   */
+  void setFocusThreshold(double focus_threshold);
 
   /**
    * @brief Set black error image in case of error.

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -3,21 +3,21 @@
 #ifndef CV_CAMERA_CAPTURE_H
 #define CV_CAMERA_CAPTURE_H
 
-#include <string>
 #include "cv_camera/exception.h"
+#include <string>
 
-#include <camera_info_manager/camera_info_manager.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.hpp>
 #include <image_transport/image_transport.hpp>
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
-#include "cv_camera/srv/grab_frame.hpp"
+#include <sensor_msgs/image_encodings.hpp>
 #include "opencv2/opencv.hpp"
-#include "std_msgs/msg/bool.hpp"
+#include <camera_info_manager/camera_info_manager.hpp>
 #include "std_msgs/msg/u_int8.hpp"
-#include "std_srvs/srv/set_bool.hpp"
+#include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
+#include "std_srvs/srv/set_bool.hpp"
+#include "cv_camera/srv/grab_frame.hpp"
 
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
@@ -33,7 +33,8 @@ using std::placeholders::_3;
 /**
  * @brief namespace of this package
  */
-namespace cv_camera {
+namespace cv_camera
+{
 
 /**
  * @brief captures by cv::VideoCapture and publishes to ROS topic.
@@ -41,321 +42,319 @@ namespace cv_camera {
  */
 class Capture
 {
-   public:
-    /**
-     * @brief costruct with ros node and topic settings
-     *
-     * @param node ROS node handle for advertise topic.
-     * @param img_topic_name name of topic to publish (this may be image_raw).
-     * @param cam_info_topic_name name of topic to publish cam info (this may be camera_info).
-     * @param buffer_size size of publisher buffer.
-     * @param frame_id frame_id of publishing messages.
-     */
-    Capture(rclcpp::Node::SharedPtr node, const std::string& img_topic_name, const std::string& cam_info_topic_name,
-            const std::string& rect_image_topic_name, const std::string& frame_id, const bool roi_exposure,
-            uint32_t buffer_size);
+public:
+  /**
+   * @brief costruct with ros node and topic settings
+   *
+   * @param node ROS node handle for advertise topic.
+   * @param img_topic_name name of topic to publish (this may be image_raw).
+   * @param cam_info_topic_name name of topic to publish cam info (this may be camera_info).
+   * @param buffer_size size of publisher buffer.
+   * @param frame_id frame_id of publishing messages.
+   */
+  Capture(rclcpp::Node::SharedPtr node,
+          const std::string &img_topic_name,
+          const std::string &cam_info_topic_name,
+          const std::string &rect_image_topic_name,
+          const std::string &frame_id,
+          const bool roi_exposure,
+          uint32_t buffer_size);
 
-    /**
-     * @brief Open capture device with device ID.
-     *
-     * @param device_id id of camera device (number from 0)
-     * @throw cv_camera::DeviceError device open failed
-     *
-     */
-    bool open(int32_t device_id);
+  /**
+   * @brief Open capture device with device ID.
+   *
+   * @param device_id id of camera device (number from 0)
+   * @throw cv_camera::DeviceError device open failed
+   *
+   */
+  bool open(int32_t device_id);
 
-    /**
-     * @brief Open capture device with device name.
-     *
-     * @param port path of the camera device
-     * @throw cv_camera::DeviceError device open failed
-     */
-    bool open(const std::string& port);
+  /**
+   * @brief Open capture device with device name.
+   *
+   * @param port path of the camera device
+   * @throw cv_camera::DeviceError device open failed
+   */
+  bool open(const std::string &port);
 
-    /**
-     * @brief Finds the equivalent camera device associated to
-     *        one port.
-     * @param command Terminal command to be executed
-     * @return command_output::Command output delivered by the terminal
-     */
-    std::string execute_command(const char* command);
-
-    /**
-     * @brief Finds the equivalent camera device associated to
-     *        one port.
-     * @param port Port number of interest
-     * @return port::DeviceError device open failed
-     */
-    std::string det_device_path(const char* port);
-
-    /**
-     * @brief Load camera info from file.
-     *
-     * This loads the camera info from the file specified in the camera_info_url parameter.
-     */
-    void loadCameraInfo();
-
-    /**
-     * @brief Rectify image using camera info.
-     *
-     * This uses the camera info loaded by loadCameraInfo() and creates a rectified image.
-     */
-    void rectify();
-
-    /**
-     * @brief Open default camera device.
-     *
-     * This opens with device 0.
-     *
-     * @throw cv_camera::DeviceError device open failed
-     */
-    void open();
-
-    /**
-     * @brief open video file instead of capture device.
-     */
-    bool openFile(const std::string& file_path);
-
-    /**
-     * @brief Close capture device.
-     * Uses release OpenCV function.
-     */
-    void close();
-
-    /**
-     * @brief Checks if capture device is opened
-     * Uses release OpenCV function.
-     */
-    bool is_opened();
-
-    /**
-     * @brief capture an image and store.
-     * to publish the captured image, call publish();
-     * @param flip_vertical flip the image around vertical axis if true
-     * @param flip_horizontal flip the image around horizontal axis if true
-     * @return true if success to capture, false if not captured.
-     */
-    bool capture(bool flip_vertical, bool flip_horizontal);
-
-    /**
-     * @brief pull an image from the camera but dont decode it
-     *
-     * @return true if success to pull, false if not pulled.
-     */
-    bool grab();
-
-    /**
-     * @brief Publish the image that is already captured by capture().
-     *
-     */
-    void publish(sensor_msgs::msg::Image::UniquePtr msg);
-
-    /**
-     * @brief accessor of CameraInfo.
-     *
-     * you have to call capture() before call this.
-     *
-     * @return CameraInfo
-     */
-    inline const sensor_msgs::msg::CameraInfo& getInfo() const { return info_; }
-
-    /**
-     * @brief accessor of cv::Mat
-     *
-     * you have to call capture() before call this.
-     *
-     * @return captured cv::Mat
-     */
-    inline const cv::Mat& getCvImage() const { return bridge_.image; }
-
-    /**
-     * @brief accessor of ROS Image message.
-     *
-     * you have to call capture() before call this.
-     *
-     * @return message pointer.
-     */
-    sensor_msgs::msg::Image::SharedPtr getImageMsgPtr();
-
-    /**
-     * @brief try capture image width
-     * @return true if success
-     */
-    inline bool setWidth(int32_t width) { return cap_.set(cv::CAP_PROP_FRAME_WIDTH, width); }
-
-    /**
-     * @brief try capture image height
-     * @return true if success
-     */
-    inline bool setHeight(int32_t height) { return cap_.set(cv::CAP_PROP_FRAME_HEIGHT, height); }
-
-    /**
-     * @brief set CV_PROP_*
-     * @return true if success
-     */
-    bool setPropertyFromParam(int property_id, const std::string& param_name);
-
-    /**
-     * @brief get CV_PROP_*
-     * @return value of property
-     */
-    double getProperty(int property_id);
-
-    /**
-     * @brief Set black error image in case of error.
-     */
-    void set_error_image(const std::string& error_msg, int width = 640, int height = 360);
-
-    /**
-     * @brief rescale camera calibration to another resolution
-     */
-    void rescaleCameraInfo(uint width, uint height);
-
-    /**
-     * @brief initialize undistort rectify map
-     */
-    void initUndistortRectifyMap();
+  /**
+   * @brief Finds the equivalent camera device associated to
+   *        one port.
+   * @param command Terminal command to be executed
+   * @return command_output::Command output delivered by the terminal
+   */
+  std::string execute_command(const char* command);
   
-    /**
-     * @brief Check if the image is empty
-     * @return True if image is empty, false otherwise
-     */
-    bool is_empty();
+  /**
+   * @brief Finds the equivalent camera device associated to
+   *        one port.
+   * @param port Port number of interest
+   * @return port::DeviceError device open failed
+   */
+  std::string det_device_path(const char* port);
+  
+  /**
+   * @brief Load camera info from file.
+   *
+   * This loads the camera info from the file specified in the camera_info_url parameter.
+   */
+  void loadCameraInfo();
 
-    /**
-     * @brief Check if the image is focused
-     * @return True if image is focused, false otherwise
-     */
-    bool isFocused();
+  /**
+   * @brief Rectify image using camera info.
+   *
+   * This uses the camera info loaded by loadCameraInfo() and creates a rectified image.
+   */
+  void rectify();
 
-   private:
-    /**
-     * @brief Get Laplacian variance of last captured image
-     * @return Laplacian variance value
-     */
-    double getLaplacianVariance();
+  /**
+   * @brief Open default camera device.
+   *
+   * This opens with device 0.
+   *
+   * @throw cv_camera::DeviceError device open failed
+   */
+  void open();
 
-    /**
-     * @brief Select appropiate encoding for the image
-     */
-    std::string mat_type2encoding(int mat_type);
+  /**
+   * @brief open video file instead of capture device.
+   */
+  bool openFile(const std::string &file_path);
 
-    /**
-     * @brief set current time to message header
-     */
-    void set_now(builtin_interfaces::msg::Time& time);
+  /**
+   * @brief Close capture device.
+   * Uses release OpenCV function.
+  */
+  void close();
 
-    /**
-     * @brief Sets the exposure of the camera based on the histogram of the image
-     * @param frame to set exposure
-     */
-    void custom_roi_exposure(cv::Mat& frame);
+  /**
+   * @brief Checks if capture device is opened
+   * Uses release OpenCV function.
+  */
+  bool is_opened();
 
-    /**
-     * @brief node handle for advertise.
-     */
-    rclcpp::Node::SharedPtr node_;
+  /**
+   * @brief capture an image and store.
+   * to publish the captured image, call publish();
+   * @param flip_vertical flip the image around vertical axis if true
+   * @param flip_horizontal flip the image around horizontal axis if true
+   * @return true if success to capture, false if not captured.
+   */
+  bool capture(bool flip_vertical, bool flip_horizontal);
 
-    /**
-     * @brief ROS image transport utility.
-     */
-    image_transport::ImageTransport it_;
+  /**
+   * @brief pull an image from the camera but dont decode it
+   *
+   * @return true if success to pull, false if not pulled.
+   */
+  bool grab();
 
-    /**
-     * @brief name of topic without namespace (usually "image_raw").
-     */
-    std::string img_topic_name_;
+  /**
+   * @brief Publish the image that is already captured by capture().
+   *
+   */
+  void publish(sensor_msgs::msg::Image::UniquePtr msg);
 
-    /**
-     * @brief name of topic without namespace (usually "camera_info").
-     */
-    std::string cam_info_topic_name_;
+  /**
+   * @brief accessor of CameraInfo.
+   *
+   * you have to call capture() before call this.
+   *
+   * @return CameraInfo
+   */
+  inline const sensor_msgs::msg::CameraInfo &getInfo() const
+  {
+    return info_;
+  }
 
-    /**
-     * @brief name of rectified topic without namespace (usually "image_rect").
-     */
-    std::string rect_img_topic_name_;
-    /**
-     * @brief header.frame_id for publishing images.
-     */
-    std::string frame_id_;
-    /**
-     * @brief Enables/Disables out custom exposure controller depending on histogram
-     */
-    bool roi_exposure_;
-    /**
-     * @brief timestamp of capture image
-     */
-    rclcpp::Time timestamp_;
-    /**
-     * @brief Rectified image
-     */
-    cv::Mat rect_image_;
-    /**
-     * @brief Rectification maps
-     */
-    cv::Mat map1_, map2_;
-    /**
-     * @brief size of publisher buffer
-     */
-    uint32_t buffer_size_;
+  /**
+   * @brief accessor of cv::Mat
+   *
+   * you have to call capture() before call this.
+   *
+   * @return captured cv::Mat
+   */
+  inline const cv::Mat &getCvImage() const
+  {
+    return bridge_.image;
+  }
 
-    /**
-     * @brief image publisher created by image_transport::ImageTransport.
-     */
-    image_transport::CameraPublisher pub_;
+  /**
+   * @brief accessor of ROS Image message.
+   *
+   * you have to call capture() before call this.
+   *
+   * @return message pointer.
+   */
+  sensor_msgs::msg::Image::SharedPtr getImageMsgPtr();
 
-    /**
-     * @brief video path to be streamed
-     */
-    std::string video_path_ = "";
+  /**
+   * @brief try capture image width
+   * @return true if success
+   */
+  inline bool setWidth(int32_t width)
+  {
+    return cap_.set(cv::CAP_PROP_FRAME_WIDTH, width);
+  }
 
-    /**
-     * @brief capture device.
-     */
-    cv::VideoCapture cap_;
+  /**
+   * @brief try capture image height
+   * @return true if success
+   */
+  inline bool setHeight(int32_t height)
+  {
+    return cap_.set(cv::CAP_PROP_FRAME_HEIGHT, height);
+  }
 
-    /**
-     * @brief this stores last captured image.
-     */
-    cv_bridge::CvImage bridge_;
+  /**
+   * @brief set CV_PROP_*
+   * @return true if success
+   */
+  bool setPropertyFromParam(int property_id, const std::string &param_name);
 
-    /**
-     * @brief this stores last captured image info.
-     *
-     * currently this has image size (width/height) only.
-     */
-    sensor_msgs::msg::CameraInfo info_;
+  /**
+   * @brief get CV_PROP_*
+   * @return value of property
+   */
+  double getProperty(int property_id);
 
-    /**
-     * @brief camera info manager
-     */
-    camera_info_manager::CameraInfoManager info_manager_;
+  /**
+   * @brief Set black error image in case of error.
+   */
+  void set_error_image(const std::string& error_msg, int width = 640, int height = 360);
 
-    /**
-     * @brief rescale_camera_info param value
-     */
-    bool rescale_camera_info_;
+  /**
+   * @brief rescale camera calibration to another resolution
+   */
+  void rescaleCameraInfo(uint width, uint height);
 
-    /**
-     * @brief capture_delay param value
-     */
-    rclcpp::Duration capture_delay_;
+  /**
+   * @brief initialize undistort rectify map
+   */
+  void initUndistortRectifyMap();
 
-    /**
-     * @brief Final publisher for image messages
-     */
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_image_ptr;
-    /**
-     * @brief Final publisher for rectified image messages
-     */
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_rect_image_ptr;
-    /**
-     * @brief Final publisher for camera info messages
-     */
-    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
+private:
+  /**
+   * @brief Select appropiate encoding for the image
+   */
+  std::string mat_type2encoding(int mat_type);
+
+  /**
+   * @brief set current time to message header
+   */
+  void set_now(builtin_interfaces::msg::Time& time);
+
+  /**
+   * @brief Sets the exposure of the camera based on the histogram of the image
+   * @param frame to set exposure
+   */
+  void custom_roi_exposure(cv::Mat& frame);
+
+  /**
+   * @brief node handle for advertise.
+   */
+  rclcpp::Node::SharedPtr node_;
+
+  /**
+   * @brief ROS image transport utility.
+   */
+  image_transport::ImageTransport it_;
+
+  /**
+   * @brief name of topic without namespace (usually "image_raw").
+   */
+  std::string img_topic_name_;
+
+  /**
+   * @brief name of topic without namespace (usually "camera_info").
+   */
+  std::string cam_info_topic_name_;
+
+  /**
+   * @brief name of rectified topic without namespace (usually "image_rect").
+   */
+  std::string rect_img_topic_name_;
+  /**
+   * @brief header.frame_id for publishing images.
+   */
+  std::string frame_id_;
+  /**
+   * @brief Enables/Disables out custom exposure controller depending on histogram
+   */
+  bool roi_exposure_;
+  /**
+   * @brief timestamp of capture image
+   */
+  rclcpp::Time timestamp_;
+  /**
+   * @brief Rectified image
+   */
+  cv::Mat rect_image_;
+  /**
+   * @brief Rectification maps
+   */
+  cv::Mat map1_, map2_;
+  /**
+   * @brief size of publisher buffer
+   */
+  uint32_t buffer_size_;
+
+  /**
+   * @brief image publisher created by image_transport::ImageTransport.
+   */
+  image_transport::CameraPublisher pub_;
+
+  /**
+   * @brief video path to be streamed
+   */
+  std::string video_path_ = "";
+
+  /**
+   * @brief capture device.
+   */
+  cv::VideoCapture cap_;
+
+  /**
+   * @brief this stores last captured image.
+   */
+  cv_bridge::CvImage bridge_;
+
+  /**
+   * @brief this stores last captured image info.
+   *
+   * currently this has image size (width/height) only.
+   */
+  sensor_msgs::msg::CameraInfo info_;
+
+  /**
+   * @brief camera info manager
+   */
+  camera_info_manager::CameraInfoManager info_manager_;
+
+  /**
+   * @brief rescale_camera_info param value
+   */
+  bool rescale_camera_info_;
+
+  /**
+   * @brief capture_delay param value
+   */
+  rclcpp::Duration capture_delay_;
+
+  /**
+   * @brief Final publisher for image messages
+   */
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_image_ptr;
+  /**
+   * @brief Final publisher for rectified image messages
+   */
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_pub_rect_image_ptr;
+  /**
+   * @brief Final publisher for camera info messages
+   */
+  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr m_pub_camera_info_ptr;
 };
 
-}  // namespace cv_camera
+} // namespace cv_camera
 
-#endif  // CV_CAMERA_CAPTURE_H
+#endif // CV_CAMERA_CAPTURE_H

--- a/include/cv_camera/driver.h
+++ b/include/cv_camera/driver.h
@@ -107,6 +107,11 @@ class Driver : public rclcpp::Node
    */
   void GrabFrameCb(shared_ptr_request_id const request_header, shared_ptr_grab_frame_request const request,
                      shared_ptr_grab_frame_response response);
+  /**
+   * @brief callback to check if the camera is focused.
+   */
+  void isCameraFocusedCb(shared_ptr_request_id const request_header, shared_ptr_bool_request const request,
+                     shared_ptr_bool_response response);
  private:
    /**
    * @brief ROS subscription for undistort request.
@@ -140,6 +145,10 @@ class Driver : public rclcpp::Node
    * @brief ROS Service for grabbing current frame.
    */
   rclcpp::Service<cv_camera::srv::GrabFrame>::SharedPtr grab_frame_srv_;
+  /**
+   * @brief ROS Service for checking if the camera is focused.
+   */
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr is_camera_focused_srv_;
   /**
    * @brief wrapper of cv::VideoCapture.
    */
@@ -297,6 +306,7 @@ class Driver : public rclcpp::Node
    */
   int video_stream_recovery_time_;
   int video_stream_recovery_tries_;
+  double focus_threshold_;  // Threshold for determining if a camera is unfocused.
 
   /**
    * @brief Reconnection attempts to open a camera port

--- a/launch/kiwi.launch.py
+++ b/launch/kiwi.launch.py
@@ -1,39 +1,41 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
-import os
 
+# Dictionary mapping camera names to their device IDs
+# The device ID is the number assigned by the OS to the camera device
+# For example, /dev/video3 would have device_id = 3
 camera_names_device_id = {
-    "left": 0,
+    "left": 3,
     # "right": 2,
     # "rear": 4,
     # "zoom": 6,
 }
-vision_bringup_path = get_package_share_directory("vision_bringup")
-cv_camera_path = get_package_share_directory("cv_camera")
-intrinsic_file = "file:///" + os.path.join(cv_camera_path, "launch", "camera_info.yaml")
-try:
-    params_path = os.path.join(vision_bringup_path, "params", "vision_params.yaml")
-except:
-    print("Unable to load config params", flush=True)
 
+vision_bringup_path = get_package_share_directory("vision_bringup")
+
+# Default paths
+default_intrinsic_file = PathJoinSubstitution([vision_bringup_path, "configs", "calibration", "intrinsic_calibration_params_2_1mm.yaml"])
+default_params_file = PathJoinSubstitution([vision_bringup_path, "params", "vision_params.yaml"])
 
 def generate_launch_description():
-
-    camera_info_url = LaunchConfiguration("camera_info_url")
+    # Declare launch arguments for camera info and params files
     declare_camera_info_url_cmd = DeclareLaunchArgument(
         "camera_info_url",
-        default_value=intrinsic_file,
-        description="path to the camera info file",
+        default_value=default_intrinsic_file,
+        description="Path to the camera info file",
     )
-    params_file = LaunchConfiguration("params_file")
     declare_params_file_cmd = DeclareLaunchArgument(
         "params_file",
-        default_value=params_path,
-        description="path to the params file",
+        default_value=default_params_file,
+        description="Path to the params file",
     )
+
+    # Use LaunchConfiguration to get the values, falling back to defaults if not provided
+    camera_info_url = LaunchConfiguration("camera_info_url")
+    params_file = LaunchConfiguration("params_file")
 
     nodes = []
     for camera_name, device_id in camera_names_device_id.items():

--- a/launch/kiwi_runtime_load.launch.py
+++ b/launch/kiwi_runtime_load.launch.py
@@ -25,7 +25,7 @@ def parse_bool2string(boolean: bool) -> str:
 try:
     base_path = get_package_share_directory("vision_bringup")
 except Exception:
-    print("Error: No shared vision_bringup directory found. It is necessary for params and intrisic files!")
+    print("Error: No shared vision_bringup directory found. It is necessary for params and intrinsic files!")
     exit(1)
 
 use_composition = parse_bool2string(int(os.getenv("VISION_USE_COMPOSITION", True)))

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -539,8 +539,8 @@ bool Capture::isFocused()
     // Calculate image focus using Laplacian variance method
     // Higher variance indicates more edges/details are in focus
     double laplacianVariance = getLaplacianVariance();
-    RCLCPP_ERROR(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), laplacianVariance);
-    RCLCPP_ERROR(node_->get_logger(), "[%s] focus_threshold_: %f", node_->get_name(), focus_threshold_);
+    RCLCPP_DEBUG(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), laplacianVariance);
+    RCLCPP_DEBUG(node_->get_logger(), "[%s] focus_threshold_: %f", node_->get_name(), focus_threshold_);
     
     // Return true if variance is above threshold (image is focused)
     return laplacianVariance >= focus_threshold_;

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -33,17 +33,17 @@ Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name
 
 void Capture::param_manager_setup() 
 {
-  node_name_ = node_->get_fully_qualified_name();
-  param_manager_ = NodeParamManager(node_);
-  param_manager_.addExternParam(focus_threshold_, std::string("/") + node_name_, "focus_threshold", 100.0);
-  param_manager_.Subscribe2ExternParams();
+  param_manager_ = NodeParamManager(node_.get());
+  param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
+  
   params_callback_handle_ =
-    this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
+    node_->add_on_set_parameters_callback(std::bind(&Capture::parameters_cb, this, _1));
 }
 
-rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
+rcl_interfaces::msg::SetParametersResult Capture::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
 {
-    auto result = param_manager_.parametersCb(parameters);
+    rcl_interfaces::msg::SetParametersResult result;
+    result = param_manager_.parametersCb(parameters);
     return result;
 }
 
@@ -550,7 +550,7 @@ bool Capture::isFocused()
     // Calculate image focus using Laplacian variance method
     // Higher variance indicates more edges/details are in focus
     double LaplacianVariance = getLaplacianVariance();
-
+    RCLCPP_ERROR(node_->get_logger(), "[%s] focus_threshold_: %f", node_->get_name(), focus_threshold_);
     // Return true if variance is above threshold (image is focused)
     return LaplacianVariance >= focus_threshold_;
 }
@@ -566,7 +566,7 @@ double Capture::getLaplacianVariance()
     cv::meanStdDev(laplacian, mean, stddev);
 
     double variance = stddev[0] * stddev[0];
-    RCLCPP_DEBUG(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
+    RCLCPP_ERROR(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
     return variance;
 }
 

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -10,7 +10,7 @@ namespace cv_camera
 namespace enc = sensor_msgs::image_encodings;
 
 Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name, const std::string &cam_info_topic_name, 
-                 const std::string &rect_img_topic_name, const std::string &frame_id, const bool roi_exposure, uint32_t buffer_size)
+                 const std::string &rect_img_topic_name, const std::string &frame_id, const bool roi_exposure, const double focus_threshold, uint32_t buffer_size)
     : node_(node),
       it_(node_),
       img_topic_name_(img_topic_name),
@@ -20,6 +20,7 @@ Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name
       roi_exposure_(roi_exposure),
       buffer_size_(buffer_size),
       info_manager_(node_.get(), frame_id),
+      focus_threshold_(focus_threshold),
       capture_delay_(rclcpp::Duration(0, 0.0))
 {
     int dur = 0;
@@ -28,24 +29,8 @@ Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name
     m_pub_camera_info_ptr = node->create_publisher<sensor_msgs::msg::CameraInfo>(cam_info_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
     node_->get_parameter_or("capture_delay", dur, dur);
     this->capture_delay_ = rclcpp::Duration(dur, 0.0);
-    this->param_manager_setup();
 }
 
-void Capture::param_manager_setup() 
-{
-  param_manager_ = NodeParamManager(node_.get());
-  param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
-  
-  params_callback_handle_ =
-    node_->add_on_set_parameters_callback(std::bind(&Capture::parameters_cb, this, _1));
-}
-
-rcl_interfaces::msg::SetParametersResult Capture::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
-{
-    rcl_interfaces::msg::SetParametersResult result;
-    result = param_manager_.parametersCb(parameters);
-    return result;
-}
 
 void Capture::loadCameraInfo()
 {
@@ -534,7 +519,6 @@ void Capture::set_error_image(const std::string& error_msg, int width, int heigh
 
 }
 
-
 bool Capture::is_empty()
 {
     if (bridge_.image.empty())
@@ -549,10 +533,12 @@ bool Capture::isFocused()
 {
     // Calculate image focus using Laplacian variance method
     // Higher variance indicates more edges/details are in focus
-    double LaplacianVariance = getLaplacianVariance();
+    double laplacianVariance = getLaplacianVariance();
+    RCLCPP_ERROR(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), laplacianVariance);
     RCLCPP_ERROR(node_->get_logger(), "[%s] focus_threshold_: %f", node_->get_name(), focus_threshold_);
+    
     // Return true if variance is above threshold (image is focused)
-    return LaplacianVariance >= focus_threshold_;
+    return laplacianVariance >= focus_threshold_;
 }
 
 double Capture::getLaplacianVariance()
@@ -566,7 +552,6 @@ double Capture::getLaplacianVariance()
     cv::meanStdDev(laplacian, mean, stddev);
 
     double variance = stddev[0] * stddev[0];
-    RCLCPP_ERROR(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
     return variance;
 }
 

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -28,6 +28,23 @@ Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name
     m_pub_camera_info_ptr = node->create_publisher<sensor_msgs::msg::CameraInfo>(cam_info_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
     node_->get_parameter_or("capture_delay", dur, dur);
     this->capture_delay_ = rclcpp::Duration(dur, 0.0);
+    this->param_manager_setup();
+}
+
+void Capture::param_manager_setup() 
+{
+  node_name_ = node_->get_fully_qualified_name();
+  param_manager_ = NodeParamManager(node_);
+  param_manager_.addExternParam(focus_threshold_, std::string("/") + node_name_, "focus_threshold", 100.0);
+  param_manager_.Subscribe2ExternParams();
+  params_callback_handle_ =
+    this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
+}
+
+rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
+{
+    auto result = param_manager_.parametersCb(parameters);
+    return result;
 }
 
 void Capture::loadCameraInfo()
@@ -530,14 +547,12 @@ bool Capture::is_empty()
 
 bool Capture::isFocused()
 {
-    double focus_threshold = 100.0;
-    node_->get_parameter_or("focus_threshold", focus_threshold, focus_threshold);
     // Calculate image focus using Laplacian variance method
     // Higher variance indicates more edges/details are in focus
     double LaplacianVariance = getLaplacianVariance();
 
     // Return true if variance is above threshold (image is focused)
-    return LaplacianVariance >= focus_threshold;
+    return LaplacianVariance >= focus_threshold_;
 }
 
 double Capture::getLaplacianVariance()

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -4,475 +4,473 @@
 #include <sstream>
 #include <string>
 
-namespace cv_camera {
+namespace cv_camera
+{
 
 namespace enc = sensor_msgs::image_encodings;
 
-Capture::Capture(rclcpp::Node::SharedPtr node, const std::string& img_topic_name,
-                 const std::string& cam_info_topic_name, const std::string& rect_img_topic_name,
-                 const std::string& frame_id, const bool roi_exposure, uint32_t buffer_size)
-    : node_(node)
-    , it_(node_)
-    , img_topic_name_(img_topic_name)
-    , cam_info_topic_name_(cam_info_topic_name)
-    , rect_img_topic_name_(rect_img_topic_name)
-    , frame_id_(frame_id)
-    , roi_exposure_(roi_exposure)
-    , buffer_size_(buffer_size)
-    , info_manager_(node_.get(), frame_id)
-    , capture_delay_(rclcpp::Duration(0, 0.0))
+Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name, const std::string &cam_info_topic_name, 
+                 const std::string &rect_img_topic_name, const std::string &frame_id, const bool roi_exposure, uint32_t buffer_size)
+    : node_(node),
+      it_(node_),
+      img_topic_name_(img_topic_name),
+      cam_info_topic_name_(cam_info_topic_name),
+      rect_img_topic_name_(rect_img_topic_name),
+      frame_id_(frame_id),
+      roi_exposure_(roi_exposure),
+      buffer_size_(buffer_size),
+      info_manager_(node_.get(), frame_id),
+      capture_delay_(rclcpp::Duration(0, 0.0))
 {
     int dur = 0;
-    m_pub_image_ptr =
-        node->create_publisher<sensor_msgs::msg::Image>(img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
-    m_pub_rect_image_ptr =
-        node->create_publisher<sensor_msgs::msg::Image>(rect_img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
-    m_pub_camera_info_ptr = node->create_publisher<sensor_msgs::msg::CameraInfo>(cam_info_topic_name_,
-                                                                                 rclcpp::QoS(rclcpp::SensorDataQoS()));
+    m_pub_image_ptr = node->create_publisher<sensor_msgs::msg::Image>(img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
+    m_pub_rect_image_ptr = node->create_publisher<sensor_msgs::msg::Image>(rect_img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
+    m_pub_camera_info_ptr = node->create_publisher<sensor_msgs::msg::CameraInfo>(cam_info_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
     node_->get_parameter_or("capture_delay", dur, dur);
     this->capture_delay_ = rclcpp::Duration(dur, 0.0);
 }
 
 void Capture::loadCameraInfo()
 {
-    std::string url;
-    if (node_->get_parameter("intrinsic_file", url))
+  std::string url;
+  if (node_->get_parameter("intrinsic_file", url))
+  {
+    if (url == "") return;
+    url = "file://" + url;
+    if (info_manager_.validateURL(url))
     {
-        if (url == "") return;
-        url = "file://" + url;
-        if (info_manager_.validateURL(url))
-        {
-            info_manager_.loadCameraInfo(url);
-        }
-        else
-        {
-            RCLCPP_ERROR(node_->get_logger(), "[%s] Invalid camera info URL %s", node_->get_name(), url.c_str());
-        }
+      info_manager_.loadCameraInfo(url);
     }
-
-    info_ = info_manager_.getCameraInfo();
-
-    // If zero distortion, just pass the message along
-    bool zero_distortion = true;
-
-    for (size_t i = 0; i < info_.d.size(); ++i)
+    else
     {
-        if (info_.d[i] != 0.0)
-        {
-            zero_distortion = false;
-            break;
-        }
+      RCLCPP_ERROR(node_->get_logger(), "[%s] Invalid camera info URL %s", node_->get_name(), url.c_str());
     }
+  }
 
-    // This will be true if D is empty/zero sized
-    if (zero_distortion)
+  info_ = info_manager_.getCameraInfo();
+
+  // If zero distortion, just pass the message along
+  bool zero_distortion = true;
+
+  for (size_t i = 0; i < info_.d.size(); ++i)
+  {
+      if (info_.d[i] != 0.0)
+      {
+          zero_distortion = false;
+          break;
+      }
+  }
+
+  // This will be true if D is empty/zero sized
+  if (zero_distortion)
+  {
+      RCLCPP_ERROR(node_->get_logger(), "[%s] No distortion coefficients found, rectification cannot be done", node_->get_name());
+      return;
+  }
+
+  initUndistortRectifyMap();
+
+  rescale_camera_info_ = false;
+  node_->get_parameter_or("rescale_camera_info", rescale_camera_info_, rescale_camera_info_);
+
+
+  for (int i = 0;; ++i)
+  {
+    int code = 0;
+    double value = 0.0;
+    std::stringstream stream;
+    stream << "property_" << i << "_code";
+    const std::string param_for_code = stream.str();
+    stream.str("");
+    stream << "property_" << i << "_value";
+    const std::string param_for_value = stream.str();
+    if (!node_->get_parameter(param_for_code, code) || !node_->get_parameter(param_for_value, value))
     {
-        RCLCPP_ERROR(node_->get_logger(), "[%s] No distortion coefficients found, rectification cannot be done",
-                     node_->get_name());
-        return;
+      break;
     }
-
-    initUndistortRectifyMap();
-
-    rescale_camera_info_ = false;
-    node_->get_parameter_or("rescale_camera_info", rescale_camera_info_, rescale_camera_info_);
-
-    for (int i = 0;; ++i)
+    if (!cap_.set(code, value))
     {
-        int code = 0;
-        double value = 0.0;
-        std::stringstream stream;
-        stream << "property_" << i << "_code";
-        const std::string param_for_code = stream.str();
-        stream.str("");
-        stream << "property_" << i << "_value";
-        const std::string param_for_value = stream.str();
-        if (!node_->get_parameter(param_for_code, code) || !node_->get_parameter(param_for_value, value))
-        {
-            break;
-        }
-        if (!cap_.set(code, value))
-        {
-            RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(), code,
-                         value);
-        }
+      RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(),code, value);
     }
+  }
 }
 
 void Capture::initUndistortRectifyMap()
 {
-    cv::Mat K = cv::Mat(3, 3, CV_64F, info_.k.data());
-    cv::Mat R = cv::Mat(3, 3, CV_64F, info_.r.data());
-    cv::Mat P = cv::Mat(3, 4, CV_64F, info_.p.data());
 
-    // select depending on distortion model
-    if (info_.distortion_model == "plumb_bob")
-    {
-        cv::Mat D = cv::Mat(1, 5, CV_64F, info_.d.data());
-        cv::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
-    }
-    else if (info_.distortion_model == "equidistant" || info_.distortion_model == "fisheye")
-    {
-        cv::Mat D = cv::Mat(1, 4, CV_64F, info_.d.data());
-        cv::fisheye::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
-    }
-    else
-    {
-        RCLCPP_ERROR(node_->get_logger(), "[%s] Unsupported distortion model: %s", node_->get_name(),
-                     info_.distortion_model.c_str());
-        return;
-    }
+  cv::Mat K = cv::Mat(3, 3, CV_64F, info_.k.data());
+  cv::Mat R = cv::Mat(3, 3, CV_64F, info_.r.data());
+  cv::Mat P = cv::Mat(3, 4, CV_64F, info_.p.data());
+
+  // select depending on distortion model
+  if (info_.distortion_model == "plumb_bob")
+  {
+      cv::Mat D = cv::Mat(1, 5, CV_64F, info_.d.data());
+      cv::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
+  }
+  else if (info_.distortion_model == "equidistant" || info_.distortion_model == "fisheye")
+  {
+      cv::Mat D = cv::Mat(1, 4, CV_64F, info_.d.data());
+      cv::fisheye::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
+  }
+  else
+  {
+      RCLCPP_ERROR(node_->get_logger(), "[%s] Unsupported distortion model: %s", node_->get_name(), info_.distortion_model.c_str());
+      return;
+  }
 }
 
 void Capture::rescaleCameraInfo(uint width, uint height)
 {
-    if (info_.width == width && info_.height == height)
-    {
-        RCLCPP_INFO(node_->get_logger(), "[%s] No rescaling needed", node_->get_name());
-        return;
-    }
+  if (info_.width == width && info_.height == height)
+  {
+    RCLCPP_INFO(node_->get_logger(), "[%s] No rescaling needed", node_->get_name());
+    return;
+  }
 
-    RCLCPP_WARN(node_->get_logger(), "[%s] Rescaling camera parameters from %dx%d to %dx%d", node_->get_name(),
-                info_.width, info_.height, width, height);
+  RCLCPP_WARN(node_->get_logger(), "[%s] Rescaling camera parameters from %dx%d to %dx%d", 
+              node_->get_name(), info_.width, info_.height, width, height);
 
-    double width_coeff = static_cast<double>(width) / info_.width;
-    double height_coeff = static_cast<double>(height) / info_.height;
-    info_.width = width;
-    info_.height = height;
+  double width_coeff = static_cast<double>(width) / info_.width;
+  double height_coeff = static_cast<double>(height) / info_.height;
+  info_.width = width;
+  info_.height = height;
 
-    // See http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html for clarification
-    info_.k[0] *= width_coeff;
-    info_.k[2] *= width_coeff;
-    info_.k[4] *= height_coeff;
-    info_.k[5] *= height_coeff;
+  // See http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html for clarification
+  info_.k[0] *= width_coeff;
+  info_.k[2] *= width_coeff;
+  info_.k[4] *= height_coeff;
+  info_.k[5] *= height_coeff;
 
-    info_.p[0] *= width_coeff;
-    info_.p[2] *= width_coeff;
-    info_.p[5] *= height_coeff;
-    info_.p[6] *= height_coeff;
+  info_.p[0] *= width_coeff;
+  info_.p[2] *= width_coeff;
+  info_.p[5] *= height_coeff;
+  info_.p[6] *= height_coeff;
 
-    initUndistortRectifyMap();
+  initUndistortRectifyMap();
 }
 
 bool Capture::open(int32_t device_id)
 {
-    cap_.open(device_id, cv::CAP_V4L2);
-    if (!cap_.isOpened())
-    {
-        return false;
-    }
-
-    loadCameraInfo();
-    return true;
+  cap_.open(device_id, cv::CAP_V4L2);
+  if (!cap_.isOpened())
+  {
+    return false;
+  }
+  
+  loadCameraInfo();
+  return true;
 }
 
-bool Capture::open(const std::string& port)
+bool Capture::open(const std::string &port)
 {
-    std::string device;
-
-    if (det_device_path(port.c_str()) != "-1")
-    {
-        device = "/dev/video" + det_device_path(port.c_str());
-    }
-    else
-    {
-        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Unable to determine device for port %s.", node_->get_name(),
-                         port.c_str());
-        return false;
-    }
-
-    cap_.open(device, cv::CAP_V4L2);
-
-    if (!cap_.isOpened())
-    {
-        return false;
-    }
-
-    loadCameraInfo();
-    return true;
+  std::string device;
+  
+  if (det_device_path(port.c_str()) != "-1")
+  {
+    device = "/dev/video" + det_device_path(port.c_str());
+  }
+  else
+  {
+    RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Unable to determine device for port %s.", node_->get_name(), port.c_str());
+    return false;
+  }
+  
+  cap_.open(device, cv::CAP_V4L2);
+  
+  if (!cap_.isOpened())
+  {
+    return false;
+  }
+  
+  loadCameraInfo();
+  return true;
 }
 
-void Capture::open() { open(0); }
-
-bool Capture::openFile(const std::string& file_path)
+void Capture::open()
 {
-    cap_.open(file_path);
-    if (!cap_.isOpened())
-    {
-        RCLCPP_ERROR(node_->get_logger(), "Unable to open file %s.", file_path.c_str());
-        return false;
-    }
+  open(0);
+}
 
-    video_path_ = file_path;
-    loadCameraInfo();
-    return true;
+bool Capture::openFile(const std::string &file_path)
+{
+  cap_.open(file_path);
+  if (!cap_.isOpened())
+  {
+    RCLCPP_ERROR(node_->get_logger(), "Unable to open file %s.", file_path.c_str());
+    return false;
+  }
+  
+  video_path_ = file_path;
+  loadCameraInfo();
+  return true;
 }
 
 bool Capture::grab()
 {
-    // Restart the video when it ends when video playback mode
-    if (video_path_ != "" && cap_.get(cv::CAP_PROP_POS_FRAMES) >= cap_.get(cv::CAP_PROP_FRAME_COUNT))
-    {
-        cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
-    }
+  // Restart the video when it ends when video playback mode
+  if (video_path_ != "" && cap_.get(cv::CAP_PROP_POS_FRAMES) >= cap_.get(cv::CAP_PROP_FRAME_COUNT))
+  {
+    cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
+  }
 
-    return cap_.grab();
+  return cap_.grab();
 }
 
 bool Capture::capture(bool flip_vertical, bool flip_horizontal)
 {
-    if (!cap_.retrieve(bridge_.image)) return false;
-    if (flip_vertical) cv::flip(bridge_.image, bridge_.image, 0);
-    if (flip_horizontal) cv::flip(bridge_.image, bridge_.image, 1);
+  if (!cap_.retrieve(bridge_.image)) return false;
+  if (flip_vertical) cv::flip(bridge_.image, bridge_.image, 0);
+  if (flip_horizontal) cv::flip(bridge_.image, bridge_.image, 1);
 
-    // Our custom made exposure set depending on ROI
-    if (roi_exposure_) custom_roi_exposure(bridge_.image);
+  // Our custom made exposure set depending on ROI
+  if (roi_exposure_) custom_roi_exposure(bridge_.image);
 
-    sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
+  sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
 
-    // Pack the OpenCV image into the ROS image.
-    timestamp_ = node_->now();
-    msg->header.stamp = timestamp_;
-    msg->header.frame_id = frame_id_;
-    msg->height = bridge_.image.rows;
-    msg->width = bridge_.image.cols;
-    msg->encoding = mat_type2encoding(bridge_.image.type());
-    msg->is_bigendian = false;
-    msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
-    msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
+  // Pack the OpenCV image into the ROS image.
+  timestamp_ = node_->now();
+  msg->header.stamp = timestamp_;
+  msg->header.frame_id = frame_id_;
+  msg->height = bridge_.image.rows;
+  msg->width = bridge_.image.cols;
+  msg->encoding = mat_type2encoding(bridge_.image.type());
+  msg->is_bigendian = false;
+  msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
+  msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
 
-    // Dont publish image if empty
-    if (bridge_.image.empty())
-    {
-        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
-        return false;
-    }
+  // Dont publish image if empty
+  if (bridge_.image.empty())
+  {
+    RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
+    return false;
+  }
 
-    // Publish the image.
-    publish(std::move(msg));
+  // Publish the image.
+  publish(std::move(msg));
 
-    // Fill the cam info message.
-    info_.header.stamp = timestamp_;
-    info_.header.frame_id = frame_id_;
+  // Fill the cam info message.
+  info_.header.stamp = timestamp_;
+  info_.header.frame_id = frame_id_;
 
-    m_pub_camera_info_ptr->publish(info_);
+  m_pub_camera_info_ptr->publish(info_);
 
-    return true;
+  return true;
 }
 
 void Capture::custom_roi_exposure(cv::Mat& frame)
 {
-    cap_.set(cv::CAP_PROP_AUTO_EXPOSURE, 1);  // disable auto exposure
-    double exposure = cap_.get(cv::CAP_PROP_EXPOSURE);
+  cap_.set(cv::CAP_PROP_AUTO_EXPOSURE, 1);  // disable auto exposure
+  double exposure = cap_.get(cv::CAP_PROP_EXPOSURE);
 
-    // define ROI for the center of the image
-    cv::Rect roi(frame.cols / 4, frame.rows / 4, frame.cols / 2, frame.rows / 2);
-    cv::Mat roiFrame = frame(roi);
+  // define ROI for the center of the image
+  cv::Rect roi(frame.cols / 4, frame.rows / 4, frame.cols / 2, frame.rows / 2);
+  cv::Mat roiFrame = frame(roi);
 
-    // convert the ROI to grayscale
-    cv::Mat grayRoi;
-    cv::cvtColor(roiFrame, grayRoi, cv::COLOR_BGR2GRAY);
+  // convert the ROI to grayscale
+  cv::Mat grayRoi;
+  cv::cvtColor(roiFrame, grayRoi, cv::COLOR_BGR2GRAY);
 
-    // calculate the histogram
-    int histSize = 256;
-    float range[] = {0, 256};  // the upper boundary is exclusive
-    const float* histRange = {range};
-    cv::Mat hist;
-    cv::calcHist(&grayRoi, 1, 0, cv::Mat(), hist, 1, &histSize, &histRange);
+  // calculate the histogram
+  int histSize = 256;
+  float range[] = { 0, 256 } ; // the upper boundary is exclusive
+  const float* histRange = { range };
+  cv::Mat hist;
+  cv::calcHist(&grayRoi, 1, 0, cv::Mat(), hist, 1, &histSize, &histRange);
 
-    // analyze the histogram to decide on exposure adjustment
-    double underExposedThreshold = 0.1 * grayRoi.total();
-    double overExposedThreshold = 0.1 * grayRoi.total();
-    // Compute overexposed and underexposed pixels
-    double underExposedPixels = 0;
-    double overExposedPixels = 0;
-    for (int i = 0; i < histSize; i++)
-    {
-        if (i < 50)
-        {
-            underExposedPixels += hist.at<float>(i);
-        }
-        else if (i > 200)
-        {
-            overExposedPixels += hist.at<float>(i);
-        }
-    }
+  // analyze the histogram to decide on exposure adjustment
+  double underExposedThreshold = 0.1 * grayRoi.total();
+  double overExposedThreshold = 0.1 * grayRoi.total();
+  // Compute overexposed and underexposed pixels
+  double underExposedPixels = 0;
+  double overExposedPixels = 0;
+  for (int i = 0; i < histSize; i++) {
+      if (i < 50) {
+          underExposedPixels += hist.at<float>(i);
+      } else if (i > 200) {
+          overExposedPixels += hist.at<float>(i);
+      }
+  }
 
-    if (underExposedPixels > underExposedThreshold)
-    {  // underexposed
-        RCLCPP_DEBUG(node_->get_logger(), "[%s] Underexposed: %f vs cap exposure: %f", node_->get_name(),
-                     underExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
-        exposure += 1;
-    }
-    else if (overExposedPixels > overExposedThreshold)
-    {  // overexposed
-        RCLCPP_DEBUG(node_->get_logger(), "[%s] Overexposed: %f vs cap exposure: %f", node_->get_name(),
-                     overExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
-        exposure -= 1;
-    }
+  if (underExposedPixels > underExposedThreshold) {  // underexposed
+      RCLCPP_DEBUG(node_->get_logger(), "[%s] Underexposed: %f vs cap exposure: %f", node_->get_name(), underExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
+      exposure += 1;
+  } else if (overExposedPixels > overExposedThreshold) {  // overexposed
+      RCLCPP_DEBUG(node_->get_logger(), "[%s] Overexposed: %f vs cap exposure: %f", node_->get_name(), overExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
+      exposure -= 1;
+  }
 
-    cap_.set(cv::CAP_PROP_EXPOSURE, exposure);  // set new exposure
+  cap_.set(cv::CAP_PROP_EXPOSURE, exposure);  // set new exposure
 }
+
 
 void Capture::rectify()
 {
     // Dont publish image if empty
-    if (bridge_.image.empty())
-    {
-        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
-        return;
-    }
+  if (bridge_.image.empty())
+  {
+    RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
+    return;
+  }
 
-    rect_image_ = bridge_.image;
+  rect_image_ = bridge_.image;
 
-    // return if map empty
-    if (map1_.empty() || map2_.empty())
-    {
-        RCLCPP_WARN_THROTTLE(
-            node_->get_logger(), *node_->get_clock(), 5000,
-            "[%s] Map1 or Map2 empty. Wont rectify the image. Check that calibration params are available",
-            node_->get_name());
-        return;
-    }
-    cv::remap(rect_image_, rect_image_, map1_, map2_, cv::INTER_LINEAR, cv::BORDER_CONSTANT, cv::Scalar());
+  // return if map empty
+  if (map1_.empty() || map2_.empty())
+  {
+      RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000, 
+        "[%s] Map1 or Map2 empty. Wont rectify the image. Check that calibration params are available", node_->get_name()
+      );
+      return;
+  }
+  cv::remap(rect_image_, rect_image_, map1_, map2_, cv::INTER_LINEAR, cv::BORDER_CONSTANT, cv::Scalar());
 
-    // Update message
-    sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
-    msg_image->header.stamp = timestamp_;
-    msg_image->header.frame_id = frame_id_;
-    msg_image->height = rect_image_.rows;
-    msg_image->width = rect_image_.cols;
-    msg_image->encoding = mat_type2encoding(rect_image_.type());
-    msg_image->is_bigendian = false;
-    msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(rect_image_.step);
-    msg_image->data.assign(rect_image_.datastart, rect_image_.dataend);
+  // Update message
+  sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
+  msg_image->header.stamp = timestamp_;
+  msg_image->header.frame_id = frame_id_;
+  msg_image->height = rect_image_.rows;
+  msg_image->width = rect_image_.cols;
+  msg_image->encoding = mat_type2encoding(rect_image_.type());
+  msg_image->is_bigendian = false;
+  msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(rect_image_.step);
+  msg_image->data.assign(rect_image_.datastart, rect_image_.dataend);
 
-    // Publish rectified image
-    m_pub_rect_image_ptr->publish(std::move(msg_image));
+  // Publish rectified image
+  m_pub_rect_image_ptr->publish(std::move(msg_image));
 }
 
-void Capture::publish(sensor_msgs::msg::Image::UniquePtr msg) { m_pub_image_ptr->publish(std::move(msg)); }
+void Capture::publish(sensor_msgs::msg::Image::UniquePtr msg)
+{
+  m_pub_image_ptr->publish(std::move(msg));
+}
 
-void Capture::close() { cap_.release(); }
+void Capture::close()
+{
+  cap_.release();
+}
 
-bool Capture::is_opened() { return cap_.isOpened(); }
+bool Capture::is_opened()
+{
+  return cap_.isOpened();
+}
 
 sensor_msgs::msg::Image::SharedPtr Capture::getImageMsgPtr()
 {
-    sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
-    msg->header.stamp = timestamp_;
-    msg->header.frame_id = frame_id_;
-    msg->height = bridge_.image.rows;
-    msg->width = bridge_.image.cols;
-    msg->encoding = mat_type2encoding(bridge_.image.type());
-    msg->is_bigendian = false;
-    msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
-    msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
+  sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
+  msg->header.stamp = timestamp_;
+  msg->header.frame_id = frame_id_;
+  msg->height = bridge_.image.rows;
+  msg->width = bridge_.image.cols;
+  msg->encoding = mat_type2encoding(bridge_.image.type());
+  msg->is_bigendian = false;
+  msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
+  msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
 
-    return msg;
+  return msg;
 }
 
-bool Capture::setPropertyFromParam(int property_id, const std::string& param_name)
+
+bool Capture::setPropertyFromParam(int property_id, const std::string &param_name)
 {
-    if (cap_.isOpened())
+  if (cap_.isOpened())
+  {
+    double value = 0.0;
+    if (node_->get_parameter(param_name, value))
     {
-        double value = 0.0;
-        if (node_->get_parameter(param_name, value))
-        {
-            if (!cap_.set(property_id, value) && value != getProperty(property_id))
-            {
-                RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(),
-                             property_id, value);
-                return false;
-            }
-        }
+      if (!cap_.set(property_id, value) && value != getProperty(property_id))
+      {
+        RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(), property_id, value);
+        return false;
+      }
     }
-    return true;
+  }
+  return true;
 }
 
 // Get VideoCapture properties
 double Capture::getProperty(int property_id)
 {
-    if (cap_.isOpened())
-    {
-        return cap_.get(property_id);
-    }
-    return 0.0;
+  if (cap_.isOpened())
+  {
+    return cap_.get(property_id);
+  }
+  return 0.0;
 }
 
 std::string Capture::execute_command(const char* command)
 {
-    std::array<char, 128> buffer;
-    std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command, "r"), pclose);
-    if (!pipe)
-    {
-        throw std::runtime_error("popen() failed!");
-    }
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
-    {
-        result += buffer.data();
-    }
-    return result;
+  std::array<char, 128> buffer;
+  std::string result;
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command, "r"), pclose);
+  if (!pipe)
+  {
+    throw std::runtime_error("popen() failed!");
+  }
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
+  {
+    result += buffer.data();
+  }
+  return result;
 }
 
 std::string Capture::det_device_path(const char* port)
 {
-    std::string video_device = "-1";
-    // TODO: instead of reading the output from shell, iter the directory
-    std::string video_devices = execute_command("ls /dev/video*");
-    std::string delimiter = "\n";
+  std::string video_device = "-1";
+  // TODO: instead of reading the output from shell, iter the directory
+  std::string video_devices = execute_command("ls /dev/video*");
+  std::string delimiter = "\n";
+  
+  size_t pos = 0;
+  std::string pre_token;
+  std::string token;
+  std::string output_command;
+  std::vector<int> devices;
+  
+  while ((pos = video_devices.find(delimiter)) != std::string::npos)
+  {
+    // get /dev/videoX substring
+    pre_token = video_devices.substr(0, pos);
+    // get number of the cam device
+    token = pre_token.substr(10, 2);
+    devices.push_back(std::stoi(token));
 
-    size_t pos = 0;
-    std::string pre_token;
-    std::string token;
-    std::string output_command;
-    std::vector<int> devices;
-
-    while ((pos = video_devices.find(delimiter)) != std::string::npos)
+    video_devices.erase(0, pos + delimiter.length());
+  }
+  
+  // Sort the vector to get devices in order
+  std::sort(devices.begin(), devices.end());
+  
+  // Iter the devices to identify which port correspond to which videoX
+  for (const auto& cam : devices)
+  {
+    output_command = "udevadm info --query=path --name=/dev/video" + std::to_string(cam);
+    std::string camera_device_info = execute_command(output_command.c_str());
+    if (camera_device_info.find(port) != std::string::npos)
     {
-        // get /dev/videoX substring
-        pre_token = video_devices.substr(0, pos);
-        // get number of the cam device
-        token = pre_token.substr(10, 2);
-        devices.push_back(std::stoi(token));
-
-        video_devices.erase(0, pos + delimiter.length());
+        video_device = std::to_string(cam);
+        return video_device;
     }
-
-    // Sort the vector to get devices in order
-    std::sort(devices.begin(), devices.end());
-
-    // Iter the devices to identify which port correspond to which videoX
-    for (const auto& cam : devices)
-    {
-        output_command = "udevadm info --query=path --name=/dev/video" + std::to_string(cam);
-        std::string camera_device_info = execute_command(output_command.c_str());
-        if (camera_device_info.find(port) != std::string::npos)
-        {
-            video_device = std::to_string(cam);
-            return video_device;
-        }
-    }
-
-    return video_device;
+  }
+  
+  return video_device;
 }
 
 std::string Capture::mat_type2encoding(int mat_type)
-{
-    switch (mat_type)
-    {
-        case CV_8UC1:
-            return "mono8";
-        case CV_8UC3:
-            return "bgr8";
-        case CV_16SC1:
-            return "mono16";
-        case CV_8UC4:
-            return "rgba8";
-        default:
-            throw std::runtime_error("Unsupported encoding type");
-    }
+  {
+      switch (mat_type)
+      {
+          case CV_8UC1:
+              return "mono8";
+          case CV_8UC3:
+              return "bgr8";
+          case CV_16SC1:
+              return "mono16";
+          case CV_8UC4:
+              return "rgba8";
+          default:
+              throw std::runtime_error("Unsupported encoding type");
+      }
 }
 
 void Capture::set_now(builtin_interfaces::msg::Time& time)
@@ -490,68 +488,32 @@ void Capture::set_now(builtin_interfaces::msg::Time& time)
 }
 void Capture::set_error_image(const std::string& error_msg, int width, int height)
 {
-    // Create frame with black image
-    cv::Mat frame_aux = cv::Mat::zeros(cv::Size(width, height), CV_8UC3);
+  // Create frame with black image
+  cv::Mat frame_aux = cv::Mat::zeros(cv::Size(width, height), CV_8UC3);
 
-    // Set font parameters
-    int font = cv::FONT_HERSHEY_SIMPLEX;
-    // empirical formula so that: when w=640 -> font=1.5 and w=1920 -> font=3.5
-    double fontScale = 0.0015625 * width + 0.3;
-    int thickness = 4;
+  // Set font parameters
+  int font = cv::FONT_HERSHEY_SIMPLEX;
+  // empirical formula so that: when w=640 -> font=1.5 and w=1920 -> font=3.5
+  double fontScale = 0.0015625 * width + 0.3;
+  int thickness = 4;
 
-    // Get text size & calculate text position
-    cv::putText(frame_aux, error_msg, cv::Point(int(width * 0.15), int(height * 0.5)), font, fontScale,
-                cv::Scalar(255, 255, 255), thickness);
+  // Get text size & calculate text position
+  cv::putText(frame_aux, error_msg, cv::Point(int(width * 0.15), int(height * 0.5)), font, fontScale,
+              cv::Scalar(255, 255, 255), thickness);
 
-    // Update message
-    sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
-    msg_image->header.stamp = timestamp_;
-    msg_image->header.frame_id = frame_id_;
-    msg_image->height = frame_aux.rows;
-    msg_image->width = frame_aux.cols;
-    msg_image->encoding = mat_type2encoding(frame_aux.type());
-    msg_image->is_bigendian = false;
-    msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(frame_aux.step);
-    msg_image->data.assign(frame_aux.datastart, frame_aux.dataend);
+  // Update message
+  sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
+  msg_image->header.stamp = timestamp_;
+  msg_image->header.frame_id = frame_id_;
+  msg_image->height = frame_aux.rows;
+  msg_image->width = frame_aux.cols;
+  msg_image->encoding = mat_type2encoding(frame_aux.type());
+  msg_image->is_bigendian = false;
+  msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(frame_aux.step);
+  msg_image->data.assign(frame_aux.datastart, frame_aux.dataend);
+  
+  // publish error image
+  publish(std::move(msg_image));
 
-    // publish error image
-    publish(std::move(msg_image));
-}
-
-bool Capture::is_empty()
-{
-    if (bridge_.image.empty())
-    {
-        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
-        return true;
-    }
-    return false;
-}
-
-bool Capture::isFocused()
-{
-    double focus_threshold = 100.0;
-    node_->get_parameter_or("focus_threshold", focus_threshold, focus_threshold);
-    // Calculate image focus using Laplacian variance method
-    // Higher variance indicates more edges/details are in focus
-    double LaplacianVariance = getLaplacianVariance();
-
-    // Return true if variance is above threshold (image is focused)
-    return LaplacianVariance >= focus_threshold;
-}
-
-double Capture::getLaplacianVariance()
-{
-    cv::Mat frame = bridge_.image;
-    cv::Mat gray, laplacian;
-    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);  // Convert to grayscale
-    cv::Laplacian(gray, laplacian, CV_64F);         // Apply Laplacian filter
-
-    cv::Scalar mean, stddev;
-    cv::meanStdDev(laplacian, mean, stddev);
-
-    double variance = stddev[0] * stddev[0];
-    RCLCPP_DEBUG(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
-    return variance;
 }
 }  // namespace cv_camera

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -4,473 +4,475 @@
 #include <sstream>
 #include <string>
 
-namespace cv_camera
-{
+namespace cv_camera {
 
 namespace enc = sensor_msgs::image_encodings;
 
-Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name, const std::string &cam_info_topic_name, 
-                 const std::string &rect_img_topic_name, const std::string &frame_id, const bool roi_exposure, uint32_t buffer_size)
-    : node_(node),
-      it_(node_),
-      img_topic_name_(img_topic_name),
-      cam_info_topic_name_(cam_info_topic_name),
-      rect_img_topic_name_(rect_img_topic_name),
-      frame_id_(frame_id),
-      roi_exposure_(roi_exposure),
-      buffer_size_(buffer_size),
-      info_manager_(node_.get(), frame_id),
-      capture_delay_(rclcpp::Duration(0, 0.0))
+Capture::Capture(rclcpp::Node::SharedPtr node, const std::string& img_topic_name,
+                 const std::string& cam_info_topic_name, const std::string& rect_img_topic_name,
+                 const std::string& frame_id, const bool roi_exposure, uint32_t buffer_size)
+    : node_(node)
+    , it_(node_)
+    , img_topic_name_(img_topic_name)
+    , cam_info_topic_name_(cam_info_topic_name)
+    , rect_img_topic_name_(rect_img_topic_name)
+    , frame_id_(frame_id)
+    , roi_exposure_(roi_exposure)
+    , buffer_size_(buffer_size)
+    , info_manager_(node_.get(), frame_id)
+    , capture_delay_(rclcpp::Duration(0, 0.0))
 {
     int dur = 0;
-    m_pub_image_ptr = node->create_publisher<sensor_msgs::msg::Image>(img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
-    m_pub_rect_image_ptr = node->create_publisher<sensor_msgs::msg::Image>(rect_img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
-    m_pub_camera_info_ptr = node->create_publisher<sensor_msgs::msg::CameraInfo>(cam_info_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
+    m_pub_image_ptr =
+        node->create_publisher<sensor_msgs::msg::Image>(img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
+    m_pub_rect_image_ptr =
+        node->create_publisher<sensor_msgs::msg::Image>(rect_img_topic_name_, rclcpp::QoS(rclcpp::SensorDataQoS()));
+    m_pub_camera_info_ptr = node->create_publisher<sensor_msgs::msg::CameraInfo>(cam_info_topic_name_,
+                                                                                 rclcpp::QoS(rclcpp::SensorDataQoS()));
     node_->get_parameter_or("capture_delay", dur, dur);
     this->capture_delay_ = rclcpp::Duration(dur, 0.0);
 }
 
 void Capture::loadCameraInfo()
 {
-  std::string url;
-  if (node_->get_parameter("intrinsic_file", url))
-  {
-    if (url == "") return;
-    url = "file://" + url;
-    if (info_manager_.validateURL(url))
+    std::string url;
+    if (node_->get_parameter("intrinsic_file", url))
     {
-      info_manager_.loadCameraInfo(url);
+        if (url == "") return;
+        url = "file://" + url;
+        if (info_manager_.validateURL(url))
+        {
+            info_manager_.loadCameraInfo(url);
+        }
+        else
+        {
+            RCLCPP_ERROR(node_->get_logger(), "[%s] Invalid camera info URL %s", node_->get_name(), url.c_str());
+        }
     }
-    else
+
+    info_ = info_manager_.getCameraInfo();
+
+    // If zero distortion, just pass the message along
+    bool zero_distortion = true;
+
+    for (size_t i = 0; i < info_.d.size(); ++i)
     {
-      RCLCPP_ERROR(node_->get_logger(), "[%s] Invalid camera info URL %s", node_->get_name(), url.c_str());
+        if (info_.d[i] != 0.0)
+        {
+            zero_distortion = false;
+            break;
+        }
     }
-  }
 
-  info_ = info_manager_.getCameraInfo();
-
-  // If zero distortion, just pass the message along
-  bool zero_distortion = true;
-
-  for (size_t i = 0; i < info_.d.size(); ++i)
-  {
-      if (info_.d[i] != 0.0)
-      {
-          zero_distortion = false;
-          break;
-      }
-  }
-
-  // This will be true if D is empty/zero sized
-  if (zero_distortion)
-  {
-      RCLCPP_ERROR(node_->get_logger(), "[%s] No distortion coefficients found, rectification cannot be done", node_->get_name());
-      return;
-  }
-
-  initUndistortRectifyMap();
-
-  rescale_camera_info_ = false;
-  node_->get_parameter_or("rescale_camera_info", rescale_camera_info_, rescale_camera_info_);
-
-
-  for (int i = 0;; ++i)
-  {
-    int code = 0;
-    double value = 0.0;
-    std::stringstream stream;
-    stream << "property_" << i << "_code";
-    const std::string param_for_code = stream.str();
-    stream.str("");
-    stream << "property_" << i << "_value";
-    const std::string param_for_value = stream.str();
-    if (!node_->get_parameter(param_for_code, code) || !node_->get_parameter(param_for_value, value))
+    // This will be true if D is empty/zero sized
+    if (zero_distortion)
     {
-      break;
+        RCLCPP_ERROR(node_->get_logger(), "[%s] No distortion coefficients found, rectification cannot be done",
+                     node_->get_name());
+        return;
     }
-    if (!cap_.set(code, value))
+
+    initUndistortRectifyMap();
+
+    rescale_camera_info_ = false;
+    node_->get_parameter_or("rescale_camera_info", rescale_camera_info_, rescale_camera_info_);
+
+    for (int i = 0;; ++i)
     {
-      RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(),code, value);
+        int code = 0;
+        double value = 0.0;
+        std::stringstream stream;
+        stream << "property_" << i << "_code";
+        const std::string param_for_code = stream.str();
+        stream.str("");
+        stream << "property_" << i << "_value";
+        const std::string param_for_value = stream.str();
+        if (!node_->get_parameter(param_for_code, code) || !node_->get_parameter(param_for_value, value))
+        {
+            break;
+        }
+        if (!cap_.set(code, value))
+        {
+            RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(), code,
+                         value);
+        }
     }
-  }
 }
 
 void Capture::initUndistortRectifyMap()
 {
+    cv::Mat K = cv::Mat(3, 3, CV_64F, info_.k.data());
+    cv::Mat R = cv::Mat(3, 3, CV_64F, info_.r.data());
+    cv::Mat P = cv::Mat(3, 4, CV_64F, info_.p.data());
 
-  cv::Mat K = cv::Mat(3, 3, CV_64F, info_.k.data());
-  cv::Mat R = cv::Mat(3, 3, CV_64F, info_.r.data());
-  cv::Mat P = cv::Mat(3, 4, CV_64F, info_.p.data());
-
-  // select depending on distortion model
-  if (info_.distortion_model == "plumb_bob")
-  {
-      cv::Mat D = cv::Mat(1, 5, CV_64F, info_.d.data());
-      cv::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
-  }
-  else if (info_.distortion_model == "equidistant" || info_.distortion_model == "fisheye")
-  {
-      cv::Mat D = cv::Mat(1, 4, CV_64F, info_.d.data());
-      cv::fisheye::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
-  }
-  else
-  {
-      RCLCPP_ERROR(node_->get_logger(), "[%s] Unsupported distortion model: %s", node_->get_name(), info_.distortion_model.c_str());
-      return;
-  }
+    // select depending on distortion model
+    if (info_.distortion_model == "plumb_bob")
+    {
+        cv::Mat D = cv::Mat(1, 5, CV_64F, info_.d.data());
+        cv::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
+    }
+    else if (info_.distortion_model == "equidistant" || info_.distortion_model == "fisheye")
+    {
+        cv::Mat D = cv::Mat(1, 4, CV_64F, info_.d.data());
+        cv::fisheye::initUndistortRectifyMap(K, D, R, P, cv::Size(info_.width, info_.height), CV_16SC2, map1_, map2_);
+    }
+    else
+    {
+        RCLCPP_ERROR(node_->get_logger(), "[%s] Unsupported distortion model: %s", node_->get_name(),
+                     info_.distortion_model.c_str());
+        return;
+    }
 }
 
 void Capture::rescaleCameraInfo(uint width, uint height)
 {
-  if (info_.width == width && info_.height == height)
-  {
-    RCLCPP_INFO(node_->get_logger(), "[%s] No rescaling needed", node_->get_name());
-    return;
-  }
+    if (info_.width == width && info_.height == height)
+    {
+        RCLCPP_INFO(node_->get_logger(), "[%s] No rescaling needed", node_->get_name());
+        return;
+    }
 
-  RCLCPP_WARN(node_->get_logger(), "[%s] Rescaling camera parameters from %dx%d to %dx%d", 
-              node_->get_name(), info_.width, info_.height, width, height);
+    RCLCPP_WARN(node_->get_logger(), "[%s] Rescaling camera parameters from %dx%d to %dx%d", node_->get_name(),
+                info_.width, info_.height, width, height);
 
-  double width_coeff = static_cast<double>(width) / info_.width;
-  double height_coeff = static_cast<double>(height) / info_.height;
-  info_.width = width;
-  info_.height = height;
+    double width_coeff = static_cast<double>(width) / info_.width;
+    double height_coeff = static_cast<double>(height) / info_.height;
+    info_.width = width;
+    info_.height = height;
 
-  // See http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html for clarification
-  info_.k[0] *= width_coeff;
-  info_.k[2] *= width_coeff;
-  info_.k[4] *= height_coeff;
-  info_.k[5] *= height_coeff;
+    // See http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html for clarification
+    info_.k[0] *= width_coeff;
+    info_.k[2] *= width_coeff;
+    info_.k[4] *= height_coeff;
+    info_.k[5] *= height_coeff;
 
-  info_.p[0] *= width_coeff;
-  info_.p[2] *= width_coeff;
-  info_.p[5] *= height_coeff;
-  info_.p[6] *= height_coeff;
+    info_.p[0] *= width_coeff;
+    info_.p[2] *= width_coeff;
+    info_.p[5] *= height_coeff;
+    info_.p[6] *= height_coeff;
 
-  initUndistortRectifyMap();
+    initUndistortRectifyMap();
 }
 
 bool Capture::open(int32_t device_id)
 {
-  cap_.open(device_id, cv::CAP_V4L2);
-  if (!cap_.isOpened())
-  {
-    return false;
-  }
-  
-  loadCameraInfo();
-  return true;
+    cap_.open(device_id, cv::CAP_V4L2);
+    if (!cap_.isOpened())
+    {
+        return false;
+    }
+
+    loadCameraInfo();
+    return true;
 }
 
-bool Capture::open(const std::string &port)
+bool Capture::open(const std::string& port)
 {
-  std::string device;
-  
-  if (det_device_path(port.c_str()) != "-1")
-  {
-    device = "/dev/video" + det_device_path(port.c_str());
-  }
-  else
-  {
-    RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Unable to determine device for port %s.", node_->get_name(), port.c_str());
-    return false;
-  }
-  
-  cap_.open(device, cv::CAP_V4L2);
-  
-  if (!cap_.isOpened())
-  {
-    return false;
-  }
-  
-  loadCameraInfo();
-  return true;
+    std::string device;
+
+    if (det_device_path(port.c_str()) != "-1")
+    {
+        device = "/dev/video" + det_device_path(port.c_str());
+    }
+    else
+    {
+        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Unable to determine device for port %s.", node_->get_name(),
+                         port.c_str());
+        return false;
+    }
+
+    cap_.open(device, cv::CAP_V4L2);
+
+    if (!cap_.isOpened())
+    {
+        return false;
+    }
+
+    loadCameraInfo();
+    return true;
 }
 
-void Capture::open()
-{
-  open(0);
-}
+void Capture::open() { open(0); }
 
-bool Capture::openFile(const std::string &file_path)
+bool Capture::openFile(const std::string& file_path)
 {
-  cap_.open(file_path);
-  if (!cap_.isOpened())
-  {
-    RCLCPP_ERROR(node_->get_logger(), "Unable to open file %s.", file_path.c_str());
-    return false;
-  }
-  
-  video_path_ = file_path;
-  loadCameraInfo();
-  return true;
+    cap_.open(file_path);
+    if (!cap_.isOpened())
+    {
+        RCLCPP_ERROR(node_->get_logger(), "Unable to open file %s.", file_path.c_str());
+        return false;
+    }
+
+    video_path_ = file_path;
+    loadCameraInfo();
+    return true;
 }
 
 bool Capture::grab()
 {
-  // Restart the video when it ends when video playback mode
-  if (video_path_ != "" && cap_.get(cv::CAP_PROP_POS_FRAMES) >= cap_.get(cv::CAP_PROP_FRAME_COUNT))
-  {
-    cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
-  }
+    // Restart the video when it ends when video playback mode
+    if (video_path_ != "" && cap_.get(cv::CAP_PROP_POS_FRAMES) >= cap_.get(cv::CAP_PROP_FRAME_COUNT))
+    {
+        cap_.set(cv::CAP_PROP_POS_FRAMES, 0);
+    }
 
-  return cap_.grab();
+    return cap_.grab();
 }
 
 bool Capture::capture(bool flip_vertical, bool flip_horizontal)
 {
-  if (!cap_.retrieve(bridge_.image)) return false;
-  if (flip_vertical) cv::flip(bridge_.image, bridge_.image, 0);
-  if (flip_horizontal) cv::flip(bridge_.image, bridge_.image, 1);
+    if (!cap_.retrieve(bridge_.image)) return false;
+    if (flip_vertical) cv::flip(bridge_.image, bridge_.image, 0);
+    if (flip_horizontal) cv::flip(bridge_.image, bridge_.image, 1);
 
-  // Our custom made exposure set depending on ROI
-  if (roi_exposure_) custom_roi_exposure(bridge_.image);
+    // Our custom made exposure set depending on ROI
+    if (roi_exposure_) custom_roi_exposure(bridge_.image);
 
-  sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
+    sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
 
-  // Pack the OpenCV image into the ROS image.
-  timestamp_ = node_->now();
-  msg->header.stamp = timestamp_;
-  msg->header.frame_id = frame_id_;
-  msg->height = bridge_.image.rows;
-  msg->width = bridge_.image.cols;
-  msg->encoding = mat_type2encoding(bridge_.image.type());
-  msg->is_bigendian = false;
-  msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
-  msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
+    // Pack the OpenCV image into the ROS image.
+    timestamp_ = node_->now();
+    msg->header.stamp = timestamp_;
+    msg->header.frame_id = frame_id_;
+    msg->height = bridge_.image.rows;
+    msg->width = bridge_.image.cols;
+    msg->encoding = mat_type2encoding(bridge_.image.type());
+    msg->is_bigendian = false;
+    msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
+    msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
 
-  // Dont publish image if empty
-  if (bridge_.image.empty())
-  {
-    RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
-    return false;
-  }
+    // Dont publish image if empty
+    if (bridge_.image.empty())
+    {
+        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
+        return false;
+    }
 
-  // Publish the image.
-  publish(std::move(msg));
+    // Publish the image.
+    publish(std::move(msg));
 
-  // Fill the cam info message.
-  info_.header.stamp = timestamp_;
-  info_.header.frame_id = frame_id_;
+    // Fill the cam info message.
+    info_.header.stamp = timestamp_;
+    info_.header.frame_id = frame_id_;
 
-  m_pub_camera_info_ptr->publish(info_);
+    m_pub_camera_info_ptr->publish(info_);
 
-  return true;
+    return true;
 }
 
 void Capture::custom_roi_exposure(cv::Mat& frame)
 {
-  cap_.set(cv::CAP_PROP_AUTO_EXPOSURE, 1);  // disable auto exposure
-  double exposure = cap_.get(cv::CAP_PROP_EXPOSURE);
+    cap_.set(cv::CAP_PROP_AUTO_EXPOSURE, 1);  // disable auto exposure
+    double exposure = cap_.get(cv::CAP_PROP_EXPOSURE);
 
-  // define ROI for the center of the image
-  cv::Rect roi(frame.cols / 4, frame.rows / 4, frame.cols / 2, frame.rows / 2);
-  cv::Mat roiFrame = frame(roi);
+    // define ROI for the center of the image
+    cv::Rect roi(frame.cols / 4, frame.rows / 4, frame.cols / 2, frame.rows / 2);
+    cv::Mat roiFrame = frame(roi);
 
-  // convert the ROI to grayscale
-  cv::Mat grayRoi;
-  cv::cvtColor(roiFrame, grayRoi, cv::COLOR_BGR2GRAY);
+    // convert the ROI to grayscale
+    cv::Mat grayRoi;
+    cv::cvtColor(roiFrame, grayRoi, cv::COLOR_BGR2GRAY);
 
-  // calculate the histogram
-  int histSize = 256;
-  float range[] = { 0, 256 } ; // the upper boundary is exclusive
-  const float* histRange = { range };
-  cv::Mat hist;
-  cv::calcHist(&grayRoi, 1, 0, cv::Mat(), hist, 1, &histSize, &histRange);
+    // calculate the histogram
+    int histSize = 256;
+    float range[] = {0, 256};  // the upper boundary is exclusive
+    const float* histRange = {range};
+    cv::Mat hist;
+    cv::calcHist(&grayRoi, 1, 0, cv::Mat(), hist, 1, &histSize, &histRange);
 
-  // analyze the histogram to decide on exposure adjustment
-  double underExposedThreshold = 0.1 * grayRoi.total();
-  double overExposedThreshold = 0.1 * grayRoi.total();
-  // Compute overexposed and underexposed pixels
-  double underExposedPixels = 0;
-  double overExposedPixels = 0;
-  for (int i = 0; i < histSize; i++) {
-      if (i < 50) {
-          underExposedPixels += hist.at<float>(i);
-      } else if (i > 200) {
-          overExposedPixels += hist.at<float>(i);
-      }
-  }
+    // analyze the histogram to decide on exposure adjustment
+    double underExposedThreshold = 0.1 * grayRoi.total();
+    double overExposedThreshold = 0.1 * grayRoi.total();
+    // Compute overexposed and underexposed pixels
+    double underExposedPixels = 0;
+    double overExposedPixels = 0;
+    for (int i = 0; i < histSize; i++)
+    {
+        if (i < 50)
+        {
+            underExposedPixels += hist.at<float>(i);
+        }
+        else if (i > 200)
+        {
+            overExposedPixels += hist.at<float>(i);
+        }
+    }
 
-  if (underExposedPixels > underExposedThreshold) {  // underexposed
-      RCLCPP_DEBUG(node_->get_logger(), "[%s] Underexposed: %f vs cap exposure: %f", node_->get_name(), underExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
-      exposure += 1;
-  } else if (overExposedPixels > overExposedThreshold) {  // overexposed
-      RCLCPP_DEBUG(node_->get_logger(), "[%s] Overexposed: %f vs cap exposure: %f", node_->get_name(), overExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
-      exposure -= 1;
-  }
+    if (underExposedPixels > underExposedThreshold)
+    {  // underexposed
+        RCLCPP_DEBUG(node_->get_logger(), "[%s] Underexposed: %f vs cap exposure: %f", node_->get_name(),
+                     underExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
+        exposure += 1;
+    }
+    else if (overExposedPixels > overExposedThreshold)
+    {  // overexposed
+        RCLCPP_DEBUG(node_->get_logger(), "[%s] Overexposed: %f vs cap exposure: %f", node_->get_name(),
+                     overExposedPixels, cap_.get(cv::CAP_PROP_EXPOSURE));
+        exposure -= 1;
+    }
 
-  cap_.set(cv::CAP_PROP_EXPOSURE, exposure);  // set new exposure
+    cap_.set(cv::CAP_PROP_EXPOSURE, exposure);  // set new exposure
 }
-
 
 void Capture::rectify()
 {
     // Dont publish image if empty
-  if (bridge_.image.empty())
-  {
-    RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
-    return;
-  }
+    if (bridge_.image.empty())
+    {
+        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
+        return;
+    }
 
-  rect_image_ = bridge_.image;
+    rect_image_ = bridge_.image;
 
-  // return if map empty
-  if (map1_.empty() || map2_.empty())
-  {
-      RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000, 
-        "[%s] Map1 or Map2 empty. Wont rectify the image. Check that calibration params are available", node_->get_name()
-      );
-      return;
-  }
-  cv::remap(rect_image_, rect_image_, map1_, map2_, cv::INTER_LINEAR, cv::BORDER_CONSTANT, cv::Scalar());
+    // return if map empty
+    if (map1_.empty() || map2_.empty())
+    {
+        RCLCPP_WARN_THROTTLE(
+            node_->get_logger(), *node_->get_clock(), 5000,
+            "[%s] Map1 or Map2 empty. Wont rectify the image. Check that calibration params are available",
+            node_->get_name());
+        return;
+    }
+    cv::remap(rect_image_, rect_image_, map1_, map2_, cv::INTER_LINEAR, cv::BORDER_CONSTANT, cv::Scalar());
 
-  // Update message
-  sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
-  msg_image->header.stamp = timestamp_;
-  msg_image->header.frame_id = frame_id_;
-  msg_image->height = rect_image_.rows;
-  msg_image->width = rect_image_.cols;
-  msg_image->encoding = mat_type2encoding(rect_image_.type());
-  msg_image->is_bigendian = false;
-  msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(rect_image_.step);
-  msg_image->data.assign(rect_image_.datastart, rect_image_.dataend);
+    // Update message
+    sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
+    msg_image->header.stamp = timestamp_;
+    msg_image->header.frame_id = frame_id_;
+    msg_image->height = rect_image_.rows;
+    msg_image->width = rect_image_.cols;
+    msg_image->encoding = mat_type2encoding(rect_image_.type());
+    msg_image->is_bigendian = false;
+    msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(rect_image_.step);
+    msg_image->data.assign(rect_image_.datastart, rect_image_.dataend);
 
-  // Publish rectified image
-  m_pub_rect_image_ptr->publish(std::move(msg_image));
+    // Publish rectified image
+    m_pub_rect_image_ptr->publish(std::move(msg_image));
 }
 
-void Capture::publish(sensor_msgs::msg::Image::UniquePtr msg)
-{
-  m_pub_image_ptr->publish(std::move(msg));
-}
+void Capture::publish(sensor_msgs::msg::Image::UniquePtr msg) { m_pub_image_ptr->publish(std::move(msg)); }
 
-void Capture::close()
-{
-  cap_.release();
-}
+void Capture::close() { cap_.release(); }
 
-bool Capture::is_opened()
-{
-  return cap_.isOpened();
-}
+bool Capture::is_opened() { return cap_.isOpened(); }
 
 sensor_msgs::msg::Image::SharedPtr Capture::getImageMsgPtr()
 {
-  sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
-  msg->header.stamp = timestamp_;
-  msg->header.frame_id = frame_id_;
-  msg->height = bridge_.image.rows;
-  msg->width = bridge_.image.cols;
-  msg->encoding = mat_type2encoding(bridge_.image.type());
-  msg->is_bigendian = false;
-  msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
-  msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
+    sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
+    msg->header.stamp = timestamp_;
+    msg->header.frame_id = frame_id_;
+    msg->height = bridge_.image.rows;
+    msg->width = bridge_.image.cols;
+    msg->encoding = mat_type2encoding(bridge_.image.type());
+    msg->is_bigendian = false;
+    msg->step = static_cast<sensor_msgs::msg::Image::_step_type>(bridge_.image.step);
+    msg->data.assign(bridge_.image.datastart, bridge_.image.dataend);
 
-  return msg;
+    return msg;
 }
 
-
-bool Capture::setPropertyFromParam(int property_id, const std::string &param_name)
+bool Capture::setPropertyFromParam(int property_id, const std::string& param_name)
 {
-  if (cap_.isOpened())
-  {
-    double value = 0.0;
-    if (node_->get_parameter(param_name, value))
+    if (cap_.isOpened())
     {
-      if (!cap_.set(property_id, value) && value != getProperty(property_id))
-      {
-        RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(), property_id, value);
-        return false;
-      }
+        double value = 0.0;
+        if (node_->get_parameter(param_name, value))
+        {
+            if (!cap_.set(property_id, value) && value != getProperty(property_id))
+            {
+                RCLCPP_ERROR(node_->get_logger(), "[%s] Setting with code %d and value %f failed", node_->get_name(),
+                             property_id, value);
+                return false;
+            }
+        }
     }
-  }
-  return true;
+    return true;
 }
 
 // Get VideoCapture properties
 double Capture::getProperty(int property_id)
 {
-  if (cap_.isOpened())
-  {
-    return cap_.get(property_id);
-  }
-  return 0.0;
+    if (cap_.isOpened())
+    {
+        return cap_.get(property_id);
+    }
+    return 0.0;
 }
 
 std::string Capture::execute_command(const char* command)
 {
-  std::array<char, 128> buffer;
-  std::string result;
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command, "r"), pclose);
-  if (!pipe)
-  {
-    throw std::runtime_error("popen() failed!");
-  }
-  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
-  {
-    result += buffer.data();
-  }
-  return result;
+    std::array<char, 128> buffer;
+    std::string result;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command, "r"), pclose);
+    if (!pipe)
+    {
+        throw std::runtime_error("popen() failed!");
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
+    {
+        result += buffer.data();
+    }
+    return result;
 }
 
 std::string Capture::det_device_path(const char* port)
 {
-  std::string video_device = "-1";
-  // TODO: instead of reading the output from shell, iter the directory
-  std::string video_devices = execute_command("ls /dev/video*");
-  std::string delimiter = "\n";
-  
-  size_t pos = 0;
-  std::string pre_token;
-  std::string token;
-  std::string output_command;
-  std::vector<int> devices;
-  
-  while ((pos = video_devices.find(delimiter)) != std::string::npos)
-  {
-    // get /dev/videoX substring
-    pre_token = video_devices.substr(0, pos);
-    // get number of the cam device
-    token = pre_token.substr(10, 2);
-    devices.push_back(std::stoi(token));
+    std::string video_device = "-1";
+    // TODO: instead of reading the output from shell, iter the directory
+    std::string video_devices = execute_command("ls /dev/video*");
+    std::string delimiter = "\n";
 
-    video_devices.erase(0, pos + delimiter.length());
-  }
-  
-  // Sort the vector to get devices in order
-  std::sort(devices.begin(), devices.end());
-  
-  // Iter the devices to identify which port correspond to which videoX
-  for (const auto& cam : devices)
-  {
-    output_command = "udevadm info --query=path --name=/dev/video" + std::to_string(cam);
-    std::string camera_device_info = execute_command(output_command.c_str());
-    if (camera_device_info.find(port) != std::string::npos)
+    size_t pos = 0;
+    std::string pre_token;
+    std::string token;
+    std::string output_command;
+    std::vector<int> devices;
+
+    while ((pos = video_devices.find(delimiter)) != std::string::npos)
     {
-        video_device = std::to_string(cam);
-        return video_device;
+        // get /dev/videoX substring
+        pre_token = video_devices.substr(0, pos);
+        // get number of the cam device
+        token = pre_token.substr(10, 2);
+        devices.push_back(std::stoi(token));
+
+        video_devices.erase(0, pos + delimiter.length());
     }
-  }
-  
-  return video_device;
+
+    // Sort the vector to get devices in order
+    std::sort(devices.begin(), devices.end());
+
+    // Iter the devices to identify which port correspond to which videoX
+    for (const auto& cam : devices)
+    {
+        output_command = "udevadm info --query=path --name=/dev/video" + std::to_string(cam);
+        std::string camera_device_info = execute_command(output_command.c_str());
+        if (camera_device_info.find(port) != std::string::npos)
+        {
+            video_device = std::to_string(cam);
+            return video_device;
+        }
+    }
+
+    return video_device;
 }
 
 std::string Capture::mat_type2encoding(int mat_type)
-  {
-      switch (mat_type)
-      {
-          case CV_8UC1:
-              return "mono8";
-          case CV_8UC3:
-              return "bgr8";
-          case CV_16SC1:
-              return "mono16";
-          case CV_8UC4:
-              return "rgba8";
-          default:
-              throw std::runtime_error("Unsupported encoding type");
-      }
+{
+    switch (mat_type)
+    {
+        case CV_8UC1:
+            return "mono8";
+        case CV_8UC3:
+            return "bgr8";
+        case CV_16SC1:
+            return "mono16";
+        case CV_8UC4:
+            return "rgba8";
+        default:
+            throw std::runtime_error("Unsupported encoding type");
+    }
 }
 
 void Capture::set_now(builtin_interfaces::msg::Time& time)
@@ -488,32 +490,68 @@ void Capture::set_now(builtin_interfaces::msg::Time& time)
 }
 void Capture::set_error_image(const std::string& error_msg, int width, int height)
 {
-  // Create frame with black image
-  cv::Mat frame_aux = cv::Mat::zeros(cv::Size(width, height), CV_8UC3);
+    // Create frame with black image
+    cv::Mat frame_aux = cv::Mat::zeros(cv::Size(width, height), CV_8UC3);
 
-  // Set font parameters
-  int font = cv::FONT_HERSHEY_SIMPLEX;
-  // empirical formula so that: when w=640 -> font=1.5 and w=1920 -> font=3.5
-  double fontScale = 0.0015625 * width + 0.3;
-  int thickness = 4;
+    // Set font parameters
+    int font = cv::FONT_HERSHEY_SIMPLEX;
+    // empirical formula so that: when w=640 -> font=1.5 and w=1920 -> font=3.5
+    double fontScale = 0.0015625 * width + 0.3;
+    int thickness = 4;
 
-  // Get text size & calculate text position
-  cv::putText(frame_aux, error_msg, cv::Point(int(width * 0.15), int(height * 0.5)), font, fontScale,
-              cv::Scalar(255, 255, 255), thickness);
+    // Get text size & calculate text position
+    cv::putText(frame_aux, error_msg, cv::Point(int(width * 0.15), int(height * 0.5)), font, fontScale,
+                cv::Scalar(255, 255, 255), thickness);
 
-  // Update message
-  sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
-  msg_image->header.stamp = timestamp_;
-  msg_image->header.frame_id = frame_id_;
-  msg_image->height = frame_aux.rows;
-  msg_image->width = frame_aux.cols;
-  msg_image->encoding = mat_type2encoding(frame_aux.type());
-  msg_image->is_bigendian = false;
-  msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(frame_aux.step);
-  msg_image->data.assign(frame_aux.datastart, frame_aux.dataend);
-  
-  // publish error image
-  publish(std::move(msg_image));
+    // Update message
+    sensor_msgs::msg::Image::UniquePtr msg_image(new sensor_msgs::msg::Image());
+    msg_image->header.stamp = timestamp_;
+    msg_image->header.frame_id = frame_id_;
+    msg_image->height = frame_aux.rows;
+    msg_image->width = frame_aux.cols;
+    msg_image->encoding = mat_type2encoding(frame_aux.type());
+    msg_image->is_bigendian = false;
+    msg_image->step = static_cast<sensor_msgs::msg::Image::_step_type>(frame_aux.step);
+    msg_image->data.assign(frame_aux.datastart, frame_aux.dataend);
 
+    // publish error image
+    publish(std::move(msg_image));
+}
+
+bool Capture::is_empty()
+{
+    if (bridge_.image.empty())
+    {
+        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
+        return true;
+    }
+    return false;
+}
+
+bool Capture::isFocused()
+{
+
+    double focus_threshold = 100.0;
+    node_->get_parameter_or("focus_threshold", focus_threshold, focus_threshold);
+    // Calculate image focus using Laplacian variance method
+    // Higher variance indicates more edges/details are in focus
+    double LaplacianVariance = getLaplacianVariance();
+    
+    // Return true if variance is above threshold (image is focused)
+    return LaplacianVariance >= focus_threshold;
+}
+
+double Capture::getLaplacianVariance()
+{
+    cv::Mat frame = bridge_.image;
+    cv::Mat gray, laplacian;
+    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);  // Convert to grayscale
+    cv::Laplacian(gray, laplacian, CV_64F);         // Apply Laplacian filter
+
+    cv::Scalar mean, stddev;
+    cv::meanStdDev(laplacian, mean, stddev);
+
+    // Return variance value
+    return stddev[0] * stddev[0];
 }
 }  // namespace cv_camera

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -551,7 +551,8 @@ double Capture::getLaplacianVariance()
     cv::Scalar mean, stddev;
     cv::meanStdDev(laplacian, mean, stddev);
 
-    // Return variance value
-    return stddev[0] * stddev[0];
+    double variance = stddev[0] * stddev[0];
+    RCLCPP_INFO(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
+    return variance;
 }
 }  // namespace cv_camera

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -10,7 +10,7 @@ namespace cv_camera
 namespace enc = sensor_msgs::image_encodings;
 
 Capture::Capture(rclcpp::Node::SharedPtr node, const std::string &img_topic_name, const std::string &cam_info_topic_name, 
-                 const std::string &rect_img_topic_name, const std::string &frame_id, const bool roi_exposure, const double focus_threshold, uint32_t buffer_size)
+                 const std::string &rect_img_topic_name, const std::string &frame_id, const bool roi_exposure, double focus_threshold, uint32_t buffer_size)
     : node_(node),
       it_(node_),
       img_topic_name_(img_topic_name),
@@ -398,6 +398,11 @@ double Capture::getProperty(int property_id)
     return cap_.get(property_id);
   }
   return 0.0;
+}
+
+void Capture::setFocusThreshold(double focus_threshold)
+{
+  focus_threshold_ = focus_threshold;
 }
 
 std::string Capture::execute_command(const char* command)

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -530,13 +530,12 @@ bool Capture::is_empty()
 
 bool Capture::isFocused()
 {
-
     double focus_threshold = 100.0;
     node_->get_parameter_or("focus_threshold", focus_threshold, focus_threshold);
     // Calculate image focus using Laplacian variance method
     // Higher variance indicates more edges/details are in focus
     double LaplacianVariance = getLaplacianVariance();
-    
+
     // Return true if variance is above threshold (image is focused)
     return LaplacianVariance >= focus_threshold;
 }
@@ -552,7 +551,7 @@ double Capture::getLaplacianVariance()
     cv::meanStdDev(laplacian, mean, stddev);
 
     double variance = stddev[0] * stddev[0];
-    RCLCPP_INFO(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
+    RCLCPP_DEBUG(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
     return variance;
 }
 }  // namespace cv_camera

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -516,4 +516,43 @@ void Capture::set_error_image(const std::string& error_msg, int width, int heigh
   publish(std::move(msg_image));
 
 }
+
+
+bool Capture::is_empty()
+{
+    if (bridge_.image.empty())
+    {
+        RCLCPP_WARN_ONCE(node_->get_logger(), "[%s] Frame is empty.", node_->get_name());
+        return true;
+    }
+    return false;
+}
+
+bool Capture::isFocused()
+{
+    double focus_threshold = 100.0;
+    node_->get_parameter_or("focus_threshold", focus_threshold, focus_threshold);
+    // Calculate image focus using Laplacian variance method
+    // Higher variance indicates more edges/details are in focus
+    double LaplacianVariance = getLaplacianVariance();
+
+    // Return true if variance is above threshold (image is focused)
+    return LaplacianVariance >= focus_threshold;
+}
+
+double Capture::getLaplacianVariance()
+{
+    cv::Mat frame = bridge_.image;
+    cv::Mat gray, laplacian;
+    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);  // Convert to grayscale
+    cv::Laplacian(gray, laplacian, CV_64F);         // Apply Laplacian filter
+
+    cv::Scalar mean, stddev;
+    cv::meanStdDev(laplacian, mean, stddev);
+
+    double variance = stddev[0] * stddev[0];
+    RCLCPP_DEBUG(node_->get_logger(), "[%s] Laplacian variance: %f", node_->get_name(), variance);
+    return variance;
+}
+
 }  // namespace cv_camera

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -105,6 +105,7 @@ bool Driver::setup()
                             "/video_mapping" + name_ + "/image_rect",
                             frame_id_,
                             roi_exposure_,
+                            focus_threshold_,
                             PUBLISHER_BUFFER_SIZE));
 
   if (video_path_ != "")

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -374,6 +374,11 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
       {
         camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
       }
+      else if (name == "focus_threshold")
+      {
+        focus_threshold_ = parameter.as_double();
+        camera_->setFocusThreshold(focus_threshold_);
+      }
     }
     else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
     {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -3,142 +3,145 @@
 #include "cv_camera/driver.h"
 #include <string>
 
-namespace {
+namespace
+{
 const double DEFAULT_RATE = 30.0;
 const int32_t PUBLISHER_BUFFER_SIZE = 1;
-}  // namespace
+}
 
-namespace cv_camera {
+namespace cv_camera
+{
 
 Driver::Driver(const rclcpp::NodeOptions& options) : Node("cv_camera", options)
 {
-    auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
-    this->parameters_setup();
-    this->setup();
+  auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
+  this->parameters_setup();
+  this->setup();
 }
 
 void Driver::parameters_setup()
 {
-    name_ = this->get_fully_qualified_name();
+  name_ = this->get_fully_qualified_name();
 
-    // OpenCV Parameters
-    this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
-    this->declare_parameter("cv_cap_prop_fourcc", 0.0);
-    this->get_parameter("fourcc", fourcc_);
-    // Decode fourcc as CV2 only accepts double values for its parameters
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc",
-                                          (double)cv::VideoWriter::fourcc(*fourcc_[0].c_str(), *fourcc_[1].c_str(),
-                                                                          *fourcc_[2].c_str(), *fourcc_[3].c_str())));
+  // OpenCV Parameters
+  this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
+  this->declare_parameter("cv_cap_prop_fourcc", 0.0);
+  this->get_parameter("fourcc", fourcc_);
+  // Decode fourcc as CV2 only accepts double values for its parameters
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc", (double)cv::VideoWriter::fourcc(
+                      *fourcc_[0].c_str(), *fourcc_[1].c_str(), *fourcc_[2].c_str(), *fourcc_[3].c_str())));
 
-    // Environment Variables | ROS Parameters
-    param_manager_ = NodeParamManager(this);
-    param_manager_.addParameter<std::string>(port_, "port", "");
-    param_manager_.addParameter(device_id_, "device_id", -1);
-    param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
-    param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
-    param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
-    param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
-    param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
-    param_manager_.addParameter(rectify_, "rectify", false);
-    param_manager_.addParameter(always_rectify_, "always_rectify", false);
-    param_manager_.addParameter(always_publish_, "always_publish", false);
-    param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
-    param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
-    param_manager_.addParameter<std::string>(video_path_, "video_path", "");
-    param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
-    param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
-    param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
-    param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
+  // Environment Variables | ROS Parameters
+  param_manager_ = NodeParamManager(this);
+  param_manager_.addParameter<std::string>(port_, "port", "");
+  param_manager_.addParameter(device_id_, "device_id", -1);
+  param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
+  param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
+  param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
+  param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
+  param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
+  param_manager_.addParameter(rectify_, "rectify", false);
+  param_manager_.addParameter(always_rectify_, "always_rectify", false);
+  param_manager_.addParameter(always_publish_, "always_publish", false);
+  param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
+  param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
+  param_manager_.addParameter<std::string>(video_path_, "video_path", "");
+  param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
+  param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
+  param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
 
-    // Video capture parameters
-    param_manager_.addParameter(width_, "width", 640);
-    param_manager_.addParameter(height_, "height", 360);
-    this->declare_parameter("cv_cap_prop_frame_width", 640.0);
-    this->declare_parameter("cv_cap_prop_frame_height", 360.0);
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-    param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
-    param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
-    param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
-    param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
-    param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
-    param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
-    param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
+  // Video capture parameters
+  param_manager_.addParameter(width_, "width", 640);
+  param_manager_.addParameter(height_, "height", 360);
+  this->declare_parameter("cv_cap_prop_frame_width", 640.0);
+  this->declare_parameter("cv_cap_prop_frame_height", 360.0);
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+  param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
+  param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
+  param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
+  param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
+  param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
+  param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
+  param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
 
-    // Subscribers
-    undistort_req_sub_ = this->create_subscription<std_msgs::msg::Bool>(
-        "/video_mapping/un_distort", 1,
-        [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
+  // Subscribers
+  undistort_req_sub_ = 
+    this->create_subscription<std_msgs::msg::Bool>("/video_mapping/un_distort", 1, 
+                    [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
 
-    // Publishers
-    // In intra process communication, we cant use transient local,
-    // so we disable the intra process for this publisher
-    rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
-    options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
-    pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>(
-        "/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
-    pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
+  // Publishers
+  // In intra process communication, we cant use transient local,
+  // so we disable the intra process for this publisher
+  rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
+  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+  pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>("/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
+  pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
 
-    // Services
-    restart_srv_ = this->create_service<std_srvs::srv::Trigger>(name_ + "/restart",
-                                                                std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
-    pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/pause_img_pub",
-                                                                  std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
-    release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/release",
-                                                                    std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
-    grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
-        name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
-    is_camera_focused_srv_ = this->create_service<std_srvs::srv::SetBool>(
-        name_ + "/is_focused", std::bind(&Driver::isCameraFocusedCb, this, _1, _2, _3));
+  // Services
+  restart_srv_ = this->create_service<std_srvs::srv::Trigger>(
+    name_ + "/restart", std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
+  pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    name_ + "/pause_img_pub", std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
+  release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    name_ + "/release", std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
+  grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
+    name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
 
-    params_callback_handle_ = this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
+  params_callback_handle_ =
+    this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
 }
 
 bool Driver::setup()
 {
-    camera_.reset(new Capture(shared_from_this(), "/video_mapping" + name_ + "/image_raw",
-                              "/video_mapping" + name_ + "/camera_info", "/video_mapping" + name_ + "/image_rect",
-                              frame_id_, roi_exposure_, PUBLISHER_BUFFER_SIZE));
 
-    if (video_path_ != "")
-    {
-        camera_->openFile(video_path_);
-    }
-    else if (device_id_ >= 0)
-    {
-        if (!camera_->open(device_id_))
-        {
-            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
-            return false;
-        }
-    }
-    else if (port_ != "")
-    {
-        if (!camera_->open(port_))
-        {
-            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
-            return false;
-        }
-    }
+  camera_.reset(new Capture(shared_from_this(),
+                            "/video_mapping" + name_ + "/image_raw",
+                            "/video_mapping" + name_ + "/camera_info",
+                            "/video_mapping" + name_ + "/image_rect",
+                            frame_id_,
+                            roi_exposure_,
+                            PUBLISHER_BUFFER_SIZE));
 
-    camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
-    camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
-    camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
-    camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-    camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-    camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-    camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-    camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-    camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-    camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
-    camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
-    camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
+  if (video_path_ != "")
+  {
+    camera_->openFile(video_path_);
+  }
+  else if (device_id_ >= 0)
+  {
+    if (!camera_->open(device_id_))
+    {
+      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
+      return false;
+    }
+  }
+  else if (port_ != "")
+  {
+    if (!camera_->open(port_))
+    {
+      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
+      return false;
+    }
+  }
+
+  camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
+  camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
+  camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
+  camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+  camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+  camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+  camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+  camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+  camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+  camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
+  camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
+  camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
 #ifdef CV_CAP_PROP_WHITE_BALANCE_U
     camera_->setPropertyFromParam(cv::CAP_PROP_WHITE_BALANCE_U, "cv_cap_prop_white_balance_u");
 #endif  // CV_CAP_PROP_WHITE_BALANCE_U
@@ -149,156 +152,155 @@ bool Driver::setup()
     camera_->setPropertyFromParam(cv::CAP_PROP_BUFFERSIZE, "cv_cap_prop_buffersize");
 #endif  // CV_CAP_PROP_BUFFERSIZE
 
-    // Timers
-    read_tmr_ =
-        this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
-    publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
-                                           std::bind(&Driver::proceed, this));
-    update_resolution_tmr_ =
-        this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
-    update_resolution_tmr_->cancel();
+  // Timers
+  read_tmr_ =
+    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
+  publish_tmr_ =
+    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)), std::bind(&Driver::proceed, this));
+  update_resolution_tmr_ =
+    this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
+  update_resolution_tmr_->cancel();
 
-    cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
-    cam_status_->data = ONLINE;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(ONLINE);
+  cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
+  cam_status_->data = ONLINE;
+  pub_cam_status_->publish(*cam_status_);
+  publish_diagnostic(ONLINE);
 
-    // set error image
-    std::stringstream error_msg;
-    auto upper_label = str_toupper(name_.c_str());
-    error_msg << upper_label << " CONNECTING...";
-    camera_->set_error_image(error_msg.str());
+  // set error image
+  std::stringstream error_msg;
+  auto upper_label = str_toupper(name_.c_str());
+  error_msg << upper_label << " CONNECTING...";
+  camera_->set_error_image(error_msg.str());
 
-    // Log camera starting configuration
-    aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
-    // Update resolution to make sure it's set correctly
-    update_resolution();
-    RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
-                name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
-                int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_),
-                int(camera_->getProperty(cv::CAP_PROP_FPS)), float(camera_->getProperty(cv::CAP_PROP_FOURCC)),
-                int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
-    return true;
+  // Log camera starting configuration
+  aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
+  // Update resolution to make sure it's set correctly
+  update_resolution();
+  RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
+              name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
+              int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_), int(camera_->getProperty(cv::CAP_PROP_FPS)),
+              float(camera_->getProperty(cv::CAP_PROP_FOURCC)), int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
+  return true;
 }
 
 void Driver::read()
 {
-    if (!camera_->is_opened()) return;
+  if (!camera_->is_opened()) return;
 
-    if (!camera_->grab())
-    {
-        camera_->close();
-    }
+  if (!camera_->grab())
+  {
+    camera_->close();
+  }
 }
 
 void Driver::proceed()
 {
-    if (video_path_ != "")
-        camera_->capture(flip_vertical_, flip_horizontal_);
+  if (video_path_ != "") camera_->capture(flip_vertical_, flip_horizontal_);
 
-    else if (!camera_->is_opened())
+  else if (!camera_->is_opened())
+  {
+    read_tmr_->cancel();
+
+    if (reconnection_routine_) 
     {
-        read_tmr_->cancel();
+      // set error image
+      std::stringstream error_msg;
+      auto upper_label = str_toupper(name_.c_str());
+      error_msg << upper_label << " " << status_map_[DISCONNECTED];
+      camera_->set_error_image(error_msg.str());
 
-        if (reconnection_routine_)
-        {
-            // set error image
-            std::stringstream error_msg;
-            auto upper_label = str_toupper(name_.c_str());
-            error_msg << upper_label << " " << status_map_[DISCONNECTED];
-            camera_->set_error_image(error_msg.str());
+      cam_status_->data = DISCONNECTED;
+      pub_cam_status_->publish(*cam_status_);
+      publish_diagnostic(DISCONNECTED);
 
-            cam_status_->data = DISCONNECTED;
-            pub_cam_status_->publish(*cam_status_);
-            publish_diagnostic(DISCONNECTED);
-
-            attempt_reconnection();
-        }
-        else
-        {
-            RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-            camera_->close();
-            cam_status_->data = LOST;
-            pub_cam_status_->publish(*cam_status_);
-            publish_diagnostic(LOST);
-
-            // set error image
-            std::stringstream error_msg;
-            auto upper_label = str_toupper(name_.c_str());
-            error_msg << upper_label << " CAMERA " << status_map_[LOST];
-            camera_->set_error_image(error_msg.str());
-
-            publish_tmr_->cancel();
-        }
+      attempt_reconnection();
     }
     else
     {
-        if (!camera_->capture(flip_vertical_, flip_horizontal_))
-        {
-            RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
-        }
-        else
-        {
-            if (always_rectify_ || (rectify_ && undistort_img_req_bool_)) camera_->rectify();
-        }
+      RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+      camera_->close();
+      cam_status_->data = LOST;
+      pub_cam_status_->publish(*cam_status_);
+      publish_diagnostic(LOST);
+
+      // set error image
+      std::stringstream error_msg;
+      auto upper_label = str_toupper(name_.c_str());
+      error_msg << upper_label << " CAMERA " << status_map_[LOST];
+      camera_->set_error_image(error_msg.str());
+
+      publish_tmr_->cancel();
     }
+  }
+  else
+  {
+    if (!camera_->capture(flip_vertical_, flip_horizontal_))
+    {
+      RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
+    }
+    else
+    {
+      if (always_rectify_ || (rectify_ && undistort_img_req_bool_))
+        camera_->rectify();
+    }
+  }
 }
 
 void Driver::attempt_reconnection()
 {
-    while (reconnection_attempts_ < video_stream_recovery_tries_)
+  while (reconnection_attempts_ < video_stream_recovery_tries_)
+  {
+    RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
+                video_stream_recovery_tries_);
+    if (camera_->open(port_))
     {
-        RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
-                    video_stream_recovery_tries_);
-        if (camera_->open(port_))
-        {
-            if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
-            {
-                read_tmr_->reset();
-                RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
-                reconnection_attempts_ = 0;
-                cam_status_->data = ONLINE;
-                pub_cam_status_->publish(*cam_status_);
-                publish_diagnostic(ONLINE);
-                return;
-            }
-            else
-            {
-                // set error image
-                std::stringstream error_msg;
-                auto upper_label = str_toupper(name_.c_str());
-                error_msg << upper_label << " " << status_map_[READING_ERROR];
-                camera_->set_error_image(error_msg.str());
-
-                cam_status_->data = READING_ERROR;
-                pub_cam_status_->publish(*cam_status_);
-                publish_diagnostic(READING_ERROR);
-            }
-        }
-        std::stringstream error_msg;
-        auto upper_label = str_toupper(name_.c_str());
-        error_msg << upper_label << " " << status_map_[DISCONNECTED];
-        camera_->set_error_image(error_msg.str());
-        reconnection_attempts_++;
-        std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
-    }
-    if (reconnection_attempts_ >= video_stream_recovery_tries_)
-    {
-        RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-        camera_->close();
-        cam_status_->data = LOST;
+      if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
+      {
+        read_tmr_->reset();
+        RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
+        reconnection_attempts_ = 0;
+        cam_status_->data = ONLINE;
         pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(LOST);
-
+        publish_diagnostic(ONLINE);
+        return;
+      }
+      else
+      {
         // set error image
         std::stringstream error_msg;
         auto upper_label = str_toupper(name_.c_str());
-        error_msg << upper_label << " CAMERA " << status_map_[LOST];
+        error_msg << upper_label << " " << status_map_[READING_ERROR];
         camera_->set_error_image(error_msg.str());
 
-        read_tmr_->cancel();
-        publish_tmr_->cancel();
+        cam_status_->data = READING_ERROR;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(READING_ERROR);
+      }
     }
+    std::stringstream error_msg;
+    auto upper_label = str_toupper(name_.c_str());
+    error_msg << upper_label << " " << status_map_[DISCONNECTED];
+    camera_->set_error_image(error_msg.str());
+    reconnection_attempts_++;
+    std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
+  }
+  if (reconnection_attempts_ >= video_stream_recovery_tries_)
+  {
+    RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+    camera_->close();
+    cam_status_->data = LOST;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(LOST);
+
+    // set error image
+    std::stringstream error_msg;
+    auto upper_label = str_toupper(name_.c_str());
+    error_msg << upper_label << " CAMERA " << status_map_[LOST];
+    camera_->set_error_image(error_msg.str());
+
+    read_tmr_->cancel();
+    publish_tmr_->cancel();
+  }
 }
 
 rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
@@ -306,296 +308,275 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
     auto result = param_manager_.parametersCb(parameters);
     /* Some extra logic after catch the new values if you need it */
     // reset the timer if publishing rate changed
-    for (auto parameter : parameters)
-    {
-        const auto& type = parameter.get_type();
-        const auto& name = parameter.get_name();
+    for (auto parameter : parameters) {
+    const auto & type = parameter.get_type();
+    const auto & name = parameter.get_name();
 
-        if (type == rclcpp::ParameterType::PARAMETER_DOUBLE)
-        {
-            if (name == "read_rate")
-            {
-                read_rate_ = parameter.as_double();
-                // Create timer with new read rate
-                RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
-                read_tmr_->cancel();
-                read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)),
-                                                    std::bind(&Driver::read, this));
-            }
-            else if (name == "publish_rate")
-            {
-                publish_rate_ = parameter.as_double();
-                // Create timer with new publish rate
-                RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
-                publish_tmr_->cancel();
-                publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
-                                                       std::bind(&Driver::proceed, this));
-            }
-            else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-            }
-            else if (name == "cv_cap_prop_brightness")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-            }
-            else if (name == "cv_cap_prop_contrast")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-            }
-            else if (name == "cv_cap_prop_saturation")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-            }
-            else if (name == "cv_cap_prop_hue")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-            }
-            else if (name == "cv_cap_prop_gain")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-            }
-            else if (name == "cv_cap_prop_exposure")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-            }
-            else if (name == "cv_cap_prop_exposure")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-            }
-            else if (name == "cv_cap_prop_auto_exposure")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
-            }
-        }
-        else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
-        {
-            if (name == "width")
-            {
-                width_ = parameter.as_int();
-                // update height to maintain aspect ratio
-                height_ = int(width_ / aspect_ratio_);
-                RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio",
-                            parameter.as_int(), height_);
-                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-                // so we need to reset the timer to update the resolution
-                update_resolution_tmr_->reset();
-            }
-            else if (name == "height")
-            {
-                height_ = parameter.as_int();
-                // update width to maintain aspect ratio
-                width_ = int(height_ * aspect_ratio_);
-                RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio",
-                            parameter.as_int(), width_);
-                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-                // so we need to reset the timer to update the resolution
-                update_resolution_tmr_->reset();
-            }
-        }
-        else if (type == rclcpp::ParameterType::PARAMETER_STRING)
-        {
-            if (name == "intrinsic_file")
-            {
-                camera_->loadCameraInfo();
-            }
-        }
-        else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
-        {
-            if (name == "roi_exposure")
-            {
-                roi_exposure_ = parameter.as_bool();
-                setup();
-            }
-            else if (name == "always_publish")
-            {
-                always_publish_ = parameter.as_bool();
-                if (cam_status_->data == PAUSED && always_publish_)
-                {
-                    read_tmr_->reset();
-                    publish_tmr_->reset();
-                    cam_status_->data = ONLINE;
-                    pub_cam_status_->publish(*cam_status_);
-                    publish_diagnostic(ONLINE);
-                }
-            }
-        }
+    if (type == rclcpp::ParameterType::PARAMETER_DOUBLE) 
+    {
+      if (name == "read_rate") 
+      {
+        read_rate_ = parameter.as_double();
+        // Create timer with new read rate
+        RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
+        read_tmr_->cancel();
+        read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), 
+                                  std::bind(&Driver::read, this));
+      } 
+      else if (name  == "publish_rate") 
+      {
+        publish_rate_ = parameter.as_double();
+        // Create timer with new publish rate
+        RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
+        publish_tmr_->cancel();
+        publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
+                                               std::bind(&Driver::proceed, this));
+      }
+      else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+      }
+      else if (name == "cv_cap_prop_brightness")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+      }
+      else if (name == "cv_cap_prop_contrast")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+      }
+      else if (name == "cv_cap_prop_saturation")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+      }
+      else if (name == "cv_cap_prop_hue")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+      }
+      else if (name == "cv_cap_prop_gain")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+      }
+      else if (name == "cv_cap_prop_exposure")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+      }
+      else if (name == "cv_cap_prop_exposure")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+      }
+      else if (name == "cv_cap_prop_auto_exposure")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
+      }
     }
+    else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
+    {
+      if (name == "width")
+      {
+        width_ = parameter.as_int();
+        // update height to maintain aspect ratio
+        height_ = int(width_ / aspect_ratio_);
+        RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio", parameter.as_int(), height_);
+        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+        // so we need to reset the timer to update the resolution
+        update_resolution_tmr_->reset();
+      }
+      else if (name == "height")
+      {
+        height_ = parameter.as_int();
+        // update width to maintain aspect ratio
+        width_ = int(height_ * aspect_ratio_);
+        RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio", parameter.as_int(), width_);
+        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+        // so we need to reset the timer to update the resolution
+        update_resolution_tmr_->reset();
+      }
+    }
+    else if (type == rclcpp::ParameterType::PARAMETER_STRING)
+    {
+      if (name == "intrinsic_file")
+      {
+        camera_->loadCameraInfo();
+      }
+    }
+    else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
+    {
+      if (name == "roi_exposure")
+      {
+        roi_exposure_ = parameter.as_bool();
+        setup();
+      }
+      else if (name == "always_publish")
+      {
+        always_publish_ = parameter.as_bool();
+        if (cam_status_->data == PAUSED && always_publish_)
+        {
+          read_tmr_->reset();
+          publish_tmr_->reset();
+          cam_status_->data = ONLINE;
+          pub_cam_status_->publish(*cam_status_);
+          publish_diagnostic(ONLINE);
+        }
+      }
+    }
+  }
     return result;
 }
 
 void Driver::RestartNodeCb(shared_ptr_request_id const, shared_ptr_trigger_request const,
-                           shared_ptr_trigger_response response)
+                          shared_ptr_trigger_response response)
 {
-    RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
-    reconnection_attempts_ = 0;
-    setup();
-    response->success = true;
-    response->message = "Camera setup will be restarted";
+  RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
+  reconnection_attempts_ = 0;
+  setup();
+  response->success = true;
+  response->message = "Camera setup will be restarted";
 }
 
 void Driver::update_resolution()
 {
-    update_resolution_tmr_->cancel();
-    if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
-    {
-        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-        camera_->rescaleCameraInfo(width_, height_);
-    }
-    if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
-    {
-        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-        camera_->rescaleCameraInfo(width_, height_);
-    }
+  update_resolution_tmr_->cancel();
+  if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
+  {
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+    camera_->rescaleCameraInfo(width_, height_);
+  }
+  if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
+  {
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+    camera_->rescaleCameraInfo(width_, height_);
+  }
 }
 
 void Driver::GrabFrameCb(shared_ptr_request_id const, shared_ptr_grab_frame_request const,
-                         shared_ptr_grab_frame_response response)
+                          shared_ptr_grab_frame_response response)
 {
-    // The sensor has a buffer so we need to grab several times to get the current image.
-    for (int i = 0; i <= 5; i++)
+  // The sensor has a buffer so we need to grab several times to get the current image.
+  for (int i = 0; i <= 5; i++)
+  {
+    if (!camera_->grab())
     {
-        if (!camera_->grab())
-        {
-            response->success = false;
-            response->message = "Failed to grab frame from camera.";
-            return;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      response->success = false;
+      response->message = "Failed to grab frame from camera.";
+      return;
     }
-    if (!camera_->capture(flip_vertical_, flip_horizontal_))
-    {
-        response->success = false;
-        response->message = "Failed to capture frame from camera.";
-        return;
-    }
-    response->frame = *camera_->getImageMsgPtr();
-    response->success = true;
-    response->message = "Successfully got frame!";
-    RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  if (!camera_->capture(flip_vertical_, flip_horizontal_))
+  {
+    response->success = false;
+    response->message = "Failed to capture frame from camera.";
     return;
-}
-
-void Driver::isCameraFocusedCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                               shared_ptr_bool_response response)
-{
-    if (!camera_)
-    {
-        response->success = false;
-        response->message = "Camera not initialized";
-        return;
-    }
-    if (camera_->is_empty())
-    {
-        response->success = false;
-        response->message = "Camera frame is empty";
-        return;
-    }
-    response->success = camera_->isFocused();
-    response->message = std::string("Camera is ") + (response->success ? "focused" : "not focused");
-    return;
+  }
+  response->frame = *camera_->getImageMsgPtr();
+  response->success = true;
+  response->message = "Successfully got frame!";
+  RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
+  return;
 }
 
 void Driver::PauseImageCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                          shared_ptr_bool_response response)
+                            shared_ptr_bool_response response)
 {
-    if (request->data && !always_publish_)
-    {
-        read_tmr_->cancel();
-        publish_tmr_->cancel();
-        cam_status_->data = PAUSED;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(PAUSED);
-        response->success = true;
-        response->message = "Camera read and pub paused";
-        return;
-    }
-    else if (cam_status_->data == PAUSED)
-    {
-        read_tmr_->reset();
-        publish_tmr_->reset();
-        cam_status_->data = ONLINE;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(ONLINE);
-        response->success = true;
-        response->message = "Camera read and pub resumed";
-        return;
-    }
+  if (request->data && !always_publish_)
+  {
+    read_tmr_->cancel();
+    publish_tmr_->cancel();
+    cam_status_->data = PAUSED;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(PAUSED);
+    response->success = true;
+    response->message = "Camera read and pub paused";
+    return;
+  }
+  else if (cam_status_->data == PAUSED)
+  {
+    read_tmr_->reset();
+    publish_tmr_->reset();
+    cam_status_->data = ONLINE;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(ONLINE);
+    response->success = true;
+    response->message = "Camera read and pub resumed";
+    return;
+  }
 }
 
+
 void Driver::ReleaseCamCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                          shared_ptr_bool_response response)
+                            shared_ptr_bool_response response)
 {
-    if (request->data)
-    {
-        read_tmr_->cancel();
-        publish_tmr_->cancel();
-        camera_->close();
-        cam_status_->data = TURNED_OFF;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(TURNED_OFF);
-        response->success = true;
-        response->message = "Camera device released";
-        return;
-    }
-    else
-    {
-        setup();
-        read_tmr_->reset();
-        publish_tmr_->reset();
-        cam_status_->data = ONLINE;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(ONLINE);
-        response->success = true;
-        response->message = "Camera read and pub resumed";
-        return;
-    }
+  if (request->data)
+  {
+    read_tmr_->cancel();
+    publish_tmr_->cancel();
+    camera_->close();
+    cam_status_->data = TURNED_OFF;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(TURNED_OFF);
+    response->success = true;
+    response->message = "Camera device released";
+    return;
+  }
+  else
+  {
+    setup();
+    read_tmr_->reset();
+    publish_tmr_->reset();
+    cam_status_->data = ONLINE;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(ONLINE);
+    response->success = true;
+    response->message = "Camera read and pub resumed";
+    return;
+  }
 }
 void Driver::publish_diagnostic(Status status)
 {
-    auto message = diagnostic_msgs::msg::DiagnosticArray();
-    message.header.stamp = this->get_clock()->now();
-    auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
-    status_msg.name = "USB Camera Status";
-    status_msg.hardware_id = "/USB" + name_;
+  auto message = diagnostic_msgs::msg::DiagnosticArray();
+  message.header.stamp = this->get_clock()->now();
+  auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
+  status_msg.name = "USB Camera Status";
+  status_msg.hardware_id = "/USB" + name_;
 
-    switch (status)
-    {
-        case ONLINE:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-            status_msg.message = "Camera is online";
-            break;
-        case DISCONNECTED:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Camera is disconnected";
-            break;
-        case LOST:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-            status_msg.message = "Camera lost";
-            break;
-        case READING_ERROR:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Reading error from camera";
-            break;
-        case PAUSED:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Camera is paused";
-            break;
-        case TURNED_OFF:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Camera is turned off";
-            break;
-        default:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-            status_msg.message = "Unrecognized camera status";
-    }
+  switch (status) {
+    case ONLINE:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+        status_msg.message = "Camera is online";
+        break;
+    case DISCONNECTED:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Camera is disconnected";
+        break;
+    case LOST:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+        status_msg.message = "Camera lost";
+        break;
+    case READING_ERROR:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Reading error from camera";
+        break;
+    case PAUSED:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Camera is paused";
+        break;
+    case TURNED_OFF:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Camera is turned off";
+        break;
+    default:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+        status_msg.message = "Unrecognized camera status";
+  }
 
-    message.status.push_back(status_msg);
-    pub_cam_diagnostic_->publish(message);
+  message.status.push_back(status_msg);
+  pub_cam_diagnostic_->publish(message);
 }
 
-Driver::~Driver() {}
+Driver::~Driver()
+{
+}
 
 }  // namespace cv_camera
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -3,141 +3,148 @@
 #include "cv_camera/driver.h"
 #include <string>
 
-namespace {
+namespace
+{
 const double DEFAULT_RATE = 30.0;
 const int32_t PUBLISHER_BUFFER_SIZE = 1;
-}  // namespace
+}
 
-namespace cv_camera {
+namespace cv_camera
+{
 
 Driver::Driver(const rclcpp::NodeOptions& options) : Node("cv_camera", options)
 {
-    auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
-    this->parameters_setup();
-    this->setup();
+  auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
+  this->parameters_setup();
+  this->setup();
 }
 
 void Driver::parameters_setup()
 {
-    name_ = this->get_fully_qualified_name();
+  name_ = this->get_fully_qualified_name();
 
-    // OpenCV Parameters
-    this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
-    this->declare_parameter("cv_cap_prop_fourcc", 0.0);
-    this->get_parameter("fourcc", fourcc_);
-    // Decode fourcc as CV2 only accepts double values for its parameters
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc",
-                                          (double)cv::VideoWriter::fourcc(*fourcc_[0].c_str(), *fourcc_[1].c_str(),
-                                                                          *fourcc_[2].c_str(), *fourcc_[3].c_str())));
+  // OpenCV Parameters
+  this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
+  this->declare_parameter("cv_cap_prop_fourcc", 0.0);
+  this->get_parameter("fourcc", fourcc_);
+  // Decode fourcc as CV2 only accepts double values for its parameters
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc", (double)cv::VideoWriter::fourcc(
+                      *fourcc_[0].c_str(), *fourcc_[1].c_str(), *fourcc_[2].c_str(), *fourcc_[3].c_str())));
 
-    // Environment Variables | ROS Parameters
-    param_manager_ = NodeParamManager(this);
-    param_manager_.addParameter<std::string>(port_, "port", "");
-    param_manager_.addParameter(device_id_, "device_id", -1);
-    param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
-    param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
-    param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
-    param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
-    param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
-    param_manager_.addParameter(rectify_, "rectify", false);
-    param_manager_.addParameter(always_rectify_, "always_rectify", false);
-    param_manager_.addParameter(always_publish_, "always_publish", false);
-    param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
-    param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
-    param_manager_.addParameter<std::string>(video_path_, "video_path", "");
-    param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
-    param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
-    param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
-    param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
+  // Environment Variables | ROS Parameters
+  param_manager_ = NodeParamManager(this);
+  param_manager_.addParameter<std::string>(port_, "port", "");
+  param_manager_.addParameter(device_id_, "device_id", -1);
+  param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
+  param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
+  param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
+  param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
+  param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
+  param_manager_.addParameter(rectify_, "rectify", false);
+  param_manager_.addParameter(always_rectify_, "always_rectify", false);
+  param_manager_.addParameter(always_publish_, "always_publish", false);
+  param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
+  param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
+  param_manager_.addParameter<std::string>(video_path_, "video_path", "");
+  param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
+  param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
+  param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
+  param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
 
-    // Video capture parameters
-    param_manager_.addParameter(width_, "width", 640);
-    param_manager_.addParameter(height_, "height", 360);
-    this->declare_parameter("cv_cap_prop_frame_width", 640.0);
-    this->declare_parameter("cv_cap_prop_frame_height", 360.0);
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-    param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
-    param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
-    param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
-    param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
-    param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
-    param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
-    param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
+  // Video capture parameters
+  param_manager_.addParameter(width_, "width", 640);
+  param_manager_.addParameter(height_, "height", 360);
+  this->declare_parameter("cv_cap_prop_frame_width", 640.0);
+  this->declare_parameter("cv_cap_prop_frame_height", 360.0);
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+  param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
+  param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
+  param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
+  param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
+  param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
+  param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
+  param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
 
-    // Subscribers
-    undistort_req_sub_ = this->create_subscription<std_msgs::msg::Bool>(
-        "/video_mapping/un_distort", 1,
-        [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
+  // Subscribers
+  undistort_req_sub_ = 
+    this->create_subscription<std_msgs::msg::Bool>("/video_mapping/un_distort", 1, 
+                    [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
 
-    // Publishers
-    // In intra process communication, we cant use transient local,
-    // so we disable the intra process for this publisher
-    rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
-    options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
-    pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>(
-        "/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
-    pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
+  // Publishers
+  // In intra process communication, we cant use transient local,
+  // so we disable the intra process for this publisher
+  rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
+  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+  pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>("/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
+  pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
 
-    // Services
-    restart_srv_ = this->create_service<std_srvs::srv::Trigger>(name_ + "/restart",
-                                                                std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
-    pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/pause_img_pub",
-                                                                  std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
-    release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/release",
-                                                                    std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
-    grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
-        name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
-    is_camera_focused_srv_ = this->create_service<std_srvs::srv::SetBool>(
+  // Services
+  restart_srv_ = this->create_service<std_srvs::srv::Trigger>(
+    name_ + "/restart", std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
+  pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    name_ + "/pause_img_pub", std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
+  release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    name_ + "/release", std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
+  grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
+    name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
+  is_camera_focused_srv_ = this->create_service<std_srvs::srv::SetBool>(
         name_ + "/is_focused", std::bind(&Driver::isCameraFocusedCb, this, _1, _2, _3));
-    params_callback_handle_ = this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
+
+  params_callback_handle_ =
+    this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
 }
 
 bool Driver::setup()
 {
-    camera_.reset(new Capture(shared_from_this(), "/video_mapping" + name_ + "/image_raw",
-                              "/video_mapping" + name_ + "/camera_info", "/video_mapping" + name_ + "/image_rect",
-                              frame_id_, roi_exposure_, PUBLISHER_BUFFER_SIZE));
 
-    if (video_path_ != "")
-    {
-        camera_->openFile(video_path_);
-    }
-    else if (device_id_ >= 0)
-    {
-        if (!camera_->open(device_id_))
-        {
-            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
-            return false;
-        }
-    }
-    else if (port_ != "")
-    {
-        if (!camera_->open(port_))
-        {
-            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
-            return false;
-        }
-    }
+  camera_.reset(new Capture(shared_from_this(),
+                            "/video_mapping" + name_ + "/image_raw",
+                            "/video_mapping" + name_ + "/camera_info",
+                            "/video_mapping" + name_ + "/image_rect",
+                            frame_id_,
+                            roi_exposure_,
+                            PUBLISHER_BUFFER_SIZE));
 
-    camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
-    camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
-    camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
-    camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
-    camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-    camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-    camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-    camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-    camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-    camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-    camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
-    camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
-    camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
+  if (video_path_ != "")
+  {
+    camera_->openFile(video_path_);
+  }
+  else if (device_id_ >= 0)
+  {
+    if (!camera_->open(device_id_))
+    {
+      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
+      return false;
+    }
+  }
+  else if (port_ != "")
+  {
+    if (!camera_->open(port_))
+    {
+      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
+      return false;
+    }
+  }
+
+  camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
+  camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
+  camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
+  camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
+  camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+  camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+  camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+  camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+  camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+  camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+  camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
+  camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
+  camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
 #ifdef CV_CAP_PROP_WHITE_BALANCE_U
     camera_->setPropertyFromParam(cv::CAP_PROP_WHITE_BALANCE_U, "cv_cap_prop_white_balance_u");
 #endif  // CV_CAP_PROP_WHITE_BALANCE_U
@@ -148,156 +155,155 @@ bool Driver::setup()
     camera_->setPropertyFromParam(cv::CAP_PROP_BUFFERSIZE, "cv_cap_prop_buffersize");
 #endif  // CV_CAP_PROP_BUFFERSIZE
 
-    // Timers
-    read_tmr_ =
-        this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
-    publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
-                                           std::bind(&Driver::proceed, this));
-    update_resolution_tmr_ =
-        this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
-    update_resolution_tmr_->cancel();
+  // Timers
+  read_tmr_ =
+    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
+  publish_tmr_ =
+    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)), std::bind(&Driver::proceed, this));
+  update_resolution_tmr_ =
+    this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
+  update_resolution_tmr_->cancel();
 
-    cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
-    cam_status_->data = ONLINE;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(ONLINE);
+  cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
+  cam_status_->data = ONLINE;
+  pub_cam_status_->publish(*cam_status_);
+  publish_diagnostic(ONLINE);
 
-    // set error image
-    std::stringstream error_msg;
-    auto upper_label = str_toupper(name_.c_str());
-    error_msg << upper_label << " CONNECTING...";
-    camera_->set_error_image(error_msg.str());
+  // set error image
+  std::stringstream error_msg;
+  auto upper_label = str_toupper(name_.c_str());
+  error_msg << upper_label << " CONNECTING...";
+  camera_->set_error_image(error_msg.str());
 
-    // Log camera starting configuration
-    aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
-    // Update resolution to make sure it's set correctly
-    update_resolution();
-    RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
-                name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
-                int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_),
-                int(camera_->getProperty(cv::CAP_PROP_FPS)), float(camera_->getProperty(cv::CAP_PROP_FOURCC)),
-                int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
-    return true;
+  // Log camera starting configuration
+  aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
+  // Update resolution to make sure it's set correctly
+  update_resolution();
+  RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
+              name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
+              int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_), int(camera_->getProperty(cv::CAP_PROP_FPS)),
+              float(camera_->getProperty(cv::CAP_PROP_FOURCC)), int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
+  return true;
 }
 
 void Driver::read()
 {
-    if (!camera_->is_opened()) return;
+  if (!camera_->is_opened()) return;
 
-    if (!camera_->grab())
-    {
-        camera_->close();
-    }
+  if (!camera_->grab())
+  {
+    camera_->close();
+  }
 }
 
 void Driver::proceed()
 {
-    if (video_path_ != "")
-        camera_->capture(flip_vertical_, flip_horizontal_);
+  if (video_path_ != "") camera_->capture(flip_vertical_, flip_horizontal_);
 
-    else if (!camera_->is_opened())
+  else if (!camera_->is_opened())
+  {
+    read_tmr_->cancel();
+
+    if (reconnection_routine_) 
     {
-        read_tmr_->cancel();
+      // set error image
+      std::stringstream error_msg;
+      auto upper_label = str_toupper(name_.c_str());
+      error_msg << upper_label << " " << status_map_[DISCONNECTED];
+      camera_->set_error_image(error_msg.str());
 
-        if (reconnection_routine_)
-        {
-            // set error image
-            std::stringstream error_msg;
-            auto upper_label = str_toupper(name_.c_str());
-            error_msg << upper_label << " " << status_map_[DISCONNECTED];
-            camera_->set_error_image(error_msg.str());
+      cam_status_->data = DISCONNECTED;
+      pub_cam_status_->publish(*cam_status_);
+      publish_diagnostic(DISCONNECTED);
 
-            cam_status_->data = DISCONNECTED;
-            pub_cam_status_->publish(*cam_status_);
-            publish_diagnostic(DISCONNECTED);
-
-            attempt_reconnection();
-        }
-        else
-        {
-            RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-            camera_->close();
-            cam_status_->data = LOST;
-            pub_cam_status_->publish(*cam_status_);
-            publish_diagnostic(LOST);
-
-            // set error image
-            std::stringstream error_msg;
-            auto upper_label = str_toupper(name_.c_str());
-            error_msg << upper_label << " CAMERA " << status_map_[LOST];
-            camera_->set_error_image(error_msg.str());
-
-            publish_tmr_->cancel();
-        }
+      attempt_reconnection();
     }
     else
     {
-        if (!camera_->capture(flip_vertical_, flip_horizontal_))
-        {
-            RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
-        }
-        else
-        {
-            if (always_rectify_ || (rectify_ && undistort_img_req_bool_)) camera_->rectify();
-        }
+      RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+      camera_->close();
+      cam_status_->data = LOST;
+      pub_cam_status_->publish(*cam_status_);
+      publish_diagnostic(LOST);
+
+      // set error image
+      std::stringstream error_msg;
+      auto upper_label = str_toupper(name_.c_str());
+      error_msg << upper_label << " CAMERA " << status_map_[LOST];
+      camera_->set_error_image(error_msg.str());
+
+      publish_tmr_->cancel();
     }
+  }
+  else
+  {
+    if (!camera_->capture(flip_vertical_, flip_horizontal_))
+    {
+      RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
+    }
+    else
+    {
+      if (always_rectify_ || (rectify_ && undistort_img_req_bool_))
+        camera_->rectify();
+    }
+  }
 }
 
 void Driver::attempt_reconnection()
 {
-    while (reconnection_attempts_ < video_stream_recovery_tries_)
+  while (reconnection_attempts_ < video_stream_recovery_tries_)
+  {
+    RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
+                video_stream_recovery_tries_);
+    if (camera_->open(port_))
     {
-        RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
-                    video_stream_recovery_tries_);
-        if (camera_->open(port_))
-        {
-            if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
-            {
-                read_tmr_->reset();
-                RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
-                reconnection_attempts_ = 0;
-                cam_status_->data = ONLINE;
-                pub_cam_status_->publish(*cam_status_);
-                publish_diagnostic(ONLINE);
-                return;
-            }
-            else
-            {
-                // set error image
-                std::stringstream error_msg;
-                auto upper_label = str_toupper(name_.c_str());
-                error_msg << upper_label << " " << status_map_[READING_ERROR];
-                camera_->set_error_image(error_msg.str());
-
-                cam_status_->data = READING_ERROR;
-                pub_cam_status_->publish(*cam_status_);
-                publish_diagnostic(READING_ERROR);
-            }
-        }
-        std::stringstream error_msg;
-        auto upper_label = str_toupper(name_.c_str());
-        error_msg << upper_label << " " << status_map_[DISCONNECTED];
-        camera_->set_error_image(error_msg.str());
-        reconnection_attempts_++;
-        std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
-    }
-    if (reconnection_attempts_ >= video_stream_recovery_tries_)
-    {
-        RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-        camera_->close();
-        cam_status_->data = LOST;
+      if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
+      {
+        read_tmr_->reset();
+        RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
+        reconnection_attempts_ = 0;
+        cam_status_->data = ONLINE;
         pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(LOST);
-
+        publish_diagnostic(ONLINE);
+        return;
+      }
+      else
+      {
         // set error image
         std::stringstream error_msg;
         auto upper_label = str_toupper(name_.c_str());
-        error_msg << upper_label << " CAMERA " << status_map_[LOST];
+        error_msg << upper_label << " " << status_map_[READING_ERROR];
         camera_->set_error_image(error_msg.str());
 
-        read_tmr_->cancel();
-        publish_tmr_->cancel();
+        cam_status_->data = READING_ERROR;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(READING_ERROR);
+      }
     }
+    std::stringstream error_msg;
+    auto upper_label = str_toupper(name_.c_str());
+    error_msg << upper_label << " " << status_map_[DISCONNECTED];
+    camera_->set_error_image(error_msg.str());
+    reconnection_attempts_++;
+    std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
+  }
+  if (reconnection_attempts_ >= video_stream_recovery_tries_)
+  {
+    RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+    camera_->close();
+    cam_status_->data = LOST;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(LOST);
+
+    // set error image
+    std::stringstream error_msg;
+    auto upper_label = str_toupper(name_.c_str());
+    error_msg << upper_label << " CAMERA " << status_map_[LOST];
+    camera_->set_error_image(error_msg.str());
+
+    read_tmr_->cancel();
+    publish_tmr_->cancel();
+  }
 }
 
 rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
@@ -305,175 +311,172 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
     auto result = param_manager_.parametersCb(parameters);
     /* Some extra logic after catch the new values if you need it */
     // reset the timer if publishing rate changed
-    for (auto parameter : parameters)
-    {
-        const auto& type = parameter.get_type();
-        const auto& name = parameter.get_name();
+    for (auto parameter : parameters) {
+    const auto & type = parameter.get_type();
+    const auto & name = parameter.get_name();
 
-        if (type == rclcpp::ParameterType::PARAMETER_DOUBLE)
-        {
-            if (name == "read_rate")
-            {
-                read_rate_ = parameter.as_double();
-                // Create timer with new read rate
-                RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
-                read_tmr_->cancel();
-                read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)),
-                                                    std::bind(&Driver::read, this));
-            }
-            else if (name == "publish_rate")
-            {
-                publish_rate_ = parameter.as_double();
-                // Create timer with new publish rate
-                RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
-                publish_tmr_->cancel();
-                publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
-                                                       std::bind(&Driver::proceed, this));
-            }
-            else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-            }
-            else if (name == "cv_cap_prop_brightness")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-            }
-            else if (name == "cv_cap_prop_contrast")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-            }
-            else if (name == "cv_cap_prop_saturation")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-            }
-            else if (name == "cv_cap_prop_hue")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-            }
-            else if (name == "cv_cap_prop_gain")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-            }
-            else if (name == "cv_cap_prop_exposure")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-            }
-            else if (name == "cv_cap_prop_exposure")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-            }
-            else if (name == "cv_cap_prop_auto_exposure")
-            {
-                camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
-            }
-        }
-        else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
-        {
-            if (name == "width")
-            {
-                width_ = parameter.as_int();
-                // update height to maintain aspect ratio
-                height_ = int(width_ / aspect_ratio_);
-                RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio",
-                            parameter.as_int(), height_);
-                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-                // so we need to reset the timer to update the resolution
-                update_resolution_tmr_->reset();
-            }
-            else if (name == "height")
-            {
-                height_ = parameter.as_int();
-                // update width to maintain aspect ratio
-                width_ = int(height_ * aspect_ratio_);
-                RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio",
-                            parameter.as_int(), width_);
-                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-                // so we need to reset the timer to update the resolution
-                update_resolution_tmr_->reset();
-            }
-        }
-        else if (type == rclcpp::ParameterType::PARAMETER_STRING)
-        {
-            if (name == "intrinsic_file")
-            {
-                camera_->loadCameraInfo();
-            }
-        }
-        else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
-        {
-            if (name == "roi_exposure")
-            {
-                roi_exposure_ = parameter.as_bool();
-                setup();
-            }
-            else if (name == "always_publish")
-            {
-                always_publish_ = parameter.as_bool();
-                if (cam_status_->data == PAUSED && always_publish_)
-                {
-                    read_tmr_->reset();
-                    publish_tmr_->reset();
-                    cam_status_->data = ONLINE;
-                    pub_cam_status_->publish(*cam_status_);
-                    publish_diagnostic(ONLINE);
-                }
-            }
-        }
+    if (type == rclcpp::ParameterType::PARAMETER_DOUBLE) 
+    {
+      if (name == "read_rate") 
+      {
+        read_rate_ = parameter.as_double();
+        // Create timer with new read rate
+        RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
+        read_tmr_->cancel();
+        read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), 
+                                  std::bind(&Driver::read, this));
+      } 
+      else if (name  == "publish_rate") 
+      {
+        publish_rate_ = parameter.as_double();
+        // Create timer with new publish rate
+        RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
+        publish_tmr_->cancel();
+        publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
+                                               std::bind(&Driver::proceed, this));
+      }
+      else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+      }
+      else if (name == "cv_cap_prop_brightness")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+      }
+      else if (name == "cv_cap_prop_contrast")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+      }
+      else if (name == "cv_cap_prop_saturation")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+      }
+      else if (name == "cv_cap_prop_hue")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+      }
+      else if (name == "cv_cap_prop_gain")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+      }
+      else if (name == "cv_cap_prop_exposure")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+      }
+      else if (name == "cv_cap_prop_exposure")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+      }
+      else if (name == "cv_cap_prop_auto_exposure")
+      {
+        camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
+      }
     }
+    else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
+    {
+      if (name == "width")
+      {
+        width_ = parameter.as_int();
+        // update height to maintain aspect ratio
+        height_ = int(width_ / aspect_ratio_);
+        RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio", parameter.as_int(), height_);
+        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+        // so we need to reset the timer to update the resolution
+        update_resolution_tmr_->reset();
+      }
+      else if (name == "height")
+      {
+        height_ = parameter.as_int();
+        // update width to maintain aspect ratio
+        width_ = int(height_ * aspect_ratio_);
+        RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio", parameter.as_int(), width_);
+        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+        // so we need to reset the timer to update the resolution
+        update_resolution_tmr_->reset();
+      }
+    }
+    else if (type == rclcpp::ParameterType::PARAMETER_STRING)
+    {
+      if (name == "intrinsic_file")
+      {
+        camera_->loadCameraInfo();
+      }
+    }
+    else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
+    {
+      if (name == "roi_exposure")
+      {
+        roi_exposure_ = parameter.as_bool();
+        setup();
+      }
+      else if (name == "always_publish")
+      {
+        always_publish_ = parameter.as_bool();
+        if (cam_status_->data == PAUSED && always_publish_)
+        {
+          read_tmr_->reset();
+          publish_tmr_->reset();
+          cam_status_->data = ONLINE;
+          pub_cam_status_->publish(*cam_status_);
+          publish_diagnostic(ONLINE);
+        }
+      }
+    }
+  }
     return result;
 }
 
 void Driver::RestartNodeCb(shared_ptr_request_id const, shared_ptr_trigger_request const,
-                           shared_ptr_trigger_response response)
+                          shared_ptr_trigger_response response)
 {
-    RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
-    reconnection_attempts_ = 0;
-    setup();
-    response->success = true;
-    response->message = "Camera setup will be restarted";
+  RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
+  reconnection_attempts_ = 0;
+  setup();
+  response->success = true;
+  response->message = "Camera setup will be restarted";
 }
 
 void Driver::update_resolution()
 {
-    update_resolution_tmr_->cancel();
-    if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
-    {
-        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-        camera_->rescaleCameraInfo(width_, height_);
-    }
-    if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
-    {
-        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-        camera_->rescaleCameraInfo(width_, height_);
-    }
+  update_resolution_tmr_->cancel();
+  if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
+  {
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+    camera_->rescaleCameraInfo(width_, height_);
+  }
+  if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
+  {
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+    camera_->rescaleCameraInfo(width_, height_);
+  }
 }
 
 void Driver::GrabFrameCb(shared_ptr_request_id const, shared_ptr_grab_frame_request const,
-                         shared_ptr_grab_frame_response response)
+                          shared_ptr_grab_frame_response response)
 {
-    // The sensor has a buffer so we need to grab several times to get the current image.
-    for (int i = 0; i <= 5; i++)
+  // The sensor has a buffer so we need to grab several times to get the current image.
+  for (int i = 0; i <= 5; i++)
+  {
+    if (!camera_->grab())
     {
-        if (!camera_->grab())
-        {
-            response->success = false;
-            response->message = "Failed to grab frame from camera.";
-            return;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      response->success = false;
+      response->message = "Failed to grab frame from camera.";
+      return;
     }
-    if (!camera_->capture(flip_vertical_, flip_horizontal_))
-    {
-        response->success = false;
-        response->message = "Failed to capture frame from camera.";
-        return;
-    }
-    response->frame = *camera_->getImageMsgPtr();
-    response->success = true;
-    response->message = "Successfully got frame!";
-    RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  if (!camera_->capture(flip_vertical_, flip_horizontal_))
+  {
+    response->success = false;
+    response->message = "Failed to capture frame from camera.";
     return;
+  }
+  response->frame = *camera_->getImageMsgPtr();
+  response->success = true;
+  response->message = "Successfully got frame!";
+  RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
+  return;
 }
 
 void Driver::isCameraFocusedCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
@@ -510,104 +513,106 @@ void Driver::isCameraFocusedCb(shared_ptr_request_id const, shared_ptr_bool_requ
 }
 
 void Driver::PauseImageCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                          shared_ptr_bool_response response)
+                            shared_ptr_bool_response response)
 {
-    if (request->data && !always_publish_)
-    {
-        read_tmr_->cancel();
-        publish_tmr_->cancel();
-        cam_status_->data = PAUSED;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(PAUSED);
-        response->success = true;
-        response->message = "Camera read and pub paused";
-        return;
-    }
-    else if (cam_status_->data == PAUSED)
-    {
-        read_tmr_->reset();
-        publish_tmr_->reset();
-        cam_status_->data = ONLINE;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(ONLINE);
-        response->success = true;
-        response->message = "Camera read and pub resumed";
-        return;
-    }
+  if (request->data && !always_publish_)
+  {
+    read_tmr_->cancel();
+    publish_tmr_->cancel();
+    cam_status_->data = PAUSED;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(PAUSED);
+    response->success = true;
+    response->message = "Camera read and pub paused";
+    return;
+  }
+  else if (cam_status_->data == PAUSED)
+  {
+    read_tmr_->reset();
+    publish_tmr_->reset();
+    cam_status_->data = ONLINE;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(ONLINE);
+    response->success = true;
+    response->message = "Camera read and pub resumed";
+    return;
+  }
 }
 
+
 void Driver::ReleaseCamCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                          shared_ptr_bool_response response)
+                            shared_ptr_bool_response response)
 {
-    if (request->data)
-    {
-        read_tmr_->cancel();
-        publish_tmr_->cancel();
-        camera_->close();
-        cam_status_->data = TURNED_OFF;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(TURNED_OFF);
-        response->success = true;
-        response->message = "Camera device released";
-        return;
-    }
-    else
-    {
-        setup();
-        read_tmr_->reset();
-        publish_tmr_->reset();
-        cam_status_->data = ONLINE;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(ONLINE);
-        response->success = true;
-        response->message = "Camera read and pub resumed";
-        return;
-    }
+  if (request->data)
+  {
+    read_tmr_->cancel();
+    publish_tmr_->cancel();
+    camera_->close();
+    cam_status_->data = TURNED_OFF;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(TURNED_OFF);
+    response->success = true;
+    response->message = "Camera device released";
+    return;
+  }
+  else
+  {
+    setup();
+    read_tmr_->reset();
+    publish_tmr_->reset();
+    cam_status_->data = ONLINE;
+    pub_cam_status_->publish(*cam_status_);
+    publish_diagnostic(ONLINE);
+    response->success = true;
+    response->message = "Camera read and pub resumed";
+    return;
+  }
 }
 void Driver::publish_diagnostic(Status status)
 {
-    auto message = diagnostic_msgs::msg::DiagnosticArray();
-    message.header.stamp = this->get_clock()->now();
-    auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
-    status_msg.name = "USB Camera Status";
-    status_msg.hardware_id = "/USB" + name_;
+  auto message = diagnostic_msgs::msg::DiagnosticArray();
+  message.header.stamp = this->get_clock()->now();
+  auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
+  status_msg.name = "USB Camera Status";
+  status_msg.hardware_id = "/USB" + name_;
 
-    switch (status)
-    {
-        case ONLINE:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-            status_msg.message = "Camera is online";
-            break;
-        case DISCONNECTED:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Camera is disconnected";
-            break;
-        case LOST:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-            status_msg.message = "Camera lost";
-            break;
-        case READING_ERROR:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Reading error from camera";
-            break;
-        case PAUSED:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Camera is paused";
-            break;
-        case TURNED_OFF:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-            status_msg.message = "Camera is turned off";
-            break;
-        default:
-            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-            status_msg.message = "Unrecognized camera status";
-    }
+  switch (status) {
+    case ONLINE:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+        status_msg.message = "Camera is online";
+        break;
+    case DISCONNECTED:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Camera is disconnected";
+        break;
+    case LOST:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+        status_msg.message = "Camera lost";
+        break;
+    case READING_ERROR:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Reading error from camera";
+        break;
+    case PAUSED:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Camera is paused";
+        break;
+    case TURNED_OFF:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Camera is turned off";
+        break;
+    default:
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+        status_msg.message = "Unrecognized camera status";
+  }
 
-    message.status.push_back(status_msg);
-    pub_cam_diagnostic_->publish(message);
+  message.status.push_back(status_msg);
+  pub_cam_diagnostic_->publish(message);
 }
 
-Driver::~Driver() {}
+Driver::~Driver()
+{
+}
 
 }  // namespace cv_camera
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -87,6 +87,9 @@ void Driver::parameters_setup()
     name_ + "/release", std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
   grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
     name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
+  is_camera_focused_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    name_ + "/is_focused", std::bind(&Driver::isCameraFocusedCb, this, _1, _2, _3));
+
 
   params_callback_handle_ =
     this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
@@ -473,6 +476,26 @@ void Driver::GrabFrameCb(shared_ptr_request_id const, shared_ptr_grab_frame_requ
   response->success = true;
   response->message = "Successfully got frame!";
   RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
+  return;
+}
+
+void Driver::isCameraFocusedCb(shared_ptr_request_id const, [[maybe_unused]] shared_ptr_bool_request const request,
+                               shared_ptr_bool_response response)
+{
+  if (!camera_)
+  {
+    response->success = false;
+    response->message = "Camera not initialized";
+    return;
+  }
+  if (camera_->is_empty())
+  {
+    response->success = false;
+    response->message = "Camera frame is empty";
+    return;
+  }
+  response->success = camera_->isFocused();
+  response->message = std::string("Camera is ") + (response->success ? "focused" : "not focused");
   return;
 }
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -3,148 +3,142 @@
 #include "cv_camera/driver.h"
 #include <string>
 
-namespace
-{
+namespace {
 const double DEFAULT_RATE = 30.0;
 const int32_t PUBLISHER_BUFFER_SIZE = 1;
-}
+}  // namespace
 
-namespace cv_camera
-{
+namespace cv_camera {
 
 Driver::Driver(const rclcpp::NodeOptions& options) : Node("cv_camera", options)
 {
-  auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
-  this->parameters_setup();
-  this->setup();
+    auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
+    this->parameters_setup();
+    this->setup();
 }
 
 void Driver::parameters_setup()
 {
-  name_ = this->get_fully_qualified_name();
+    name_ = this->get_fully_qualified_name();
 
-  // OpenCV Parameters
-  this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
-  this->declare_parameter("cv_cap_prop_fourcc", 0.0);
-  this->get_parameter("fourcc", fourcc_);
-  // Decode fourcc as CV2 only accepts double values for its parameters
-  this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc", (double)cv::VideoWriter::fourcc(
-                      *fourcc_[0].c_str(), *fourcc_[1].c_str(), *fourcc_[2].c_str(), *fourcc_[3].c_str())));
+    // OpenCV Parameters
+    this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
+    this->declare_parameter("cv_cap_prop_fourcc", 0.0);
+    this->get_parameter("fourcc", fourcc_);
+    // Decode fourcc as CV2 only accepts double values for its parameters
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc",
+                                          (double)cv::VideoWriter::fourcc(*fourcc_[0].c_str(), *fourcc_[1].c_str(),
+                                                                          *fourcc_[2].c_str(), *fourcc_[3].c_str())));
 
-  // Environment Variables | ROS Parameters
-  param_manager_ = NodeParamManager(this);
-  param_manager_.addParameter<std::string>(port_, "port", "");
-  param_manager_.addParameter(device_id_, "device_id", -1);
-  param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
-  param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
-  param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
-  param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
-  param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
-  param_manager_.addParameter(rectify_, "rectify", false);
-  param_manager_.addParameter(always_rectify_, "always_rectify", false);
-  param_manager_.addParameter(always_publish_, "always_publish", false);
-  param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
-  param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
-  param_manager_.addParameter<std::string>(video_path_, "video_path", "");
-  param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
-  param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
-  param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
-  param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
+    // Environment Variables | ROS Parameters
+    param_manager_ = NodeParamManager(this);
+    param_manager_.addParameter<std::string>(port_, "port", "");
+    param_manager_.addParameter(device_id_, "device_id", -1);
+    param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
+    param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
+    param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
+    param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
+    param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
+    param_manager_.addParameter(rectify_, "rectify", false);
+    param_manager_.addParameter(always_rectify_, "always_rectify", false);
+    param_manager_.addParameter(always_publish_, "always_publish", false);
+    param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
+    param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
+    param_manager_.addParameter<std::string>(video_path_, "video_path", "");
+    param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
+    param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
+    param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
+    param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
 
-  // Video capture parameters
-  param_manager_.addParameter(width_, "width", 640);
-  param_manager_.addParameter(height_, "height", 360);
-  this->declare_parameter("cv_cap_prop_frame_width", 640.0);
-  this->declare_parameter("cv_cap_prop_frame_height", 360.0);
-  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-  param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
-  param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
-  param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
-  param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
-  param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
-  param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
-  param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
+    // Video capture parameters
+    param_manager_.addParameter(width_, "width", 640);
+    param_manager_.addParameter(height_, "height", 360);
+    this->declare_parameter("cv_cap_prop_frame_width", 640.0);
+    this->declare_parameter("cv_cap_prop_frame_height", 360.0);
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+    param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
+    param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
+    param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
+    param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
+    param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
+    param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
+    param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
 
-  // Subscribers
-  undistort_req_sub_ = 
-    this->create_subscription<std_msgs::msg::Bool>("/video_mapping/un_distort", 1, 
-                    [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
+    // Subscribers
+    undistort_req_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+        "/video_mapping/un_distort", 1,
+        [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
 
-  // Publishers
-  // In intra process communication, we cant use transient local,
-  // so we disable the intra process for this publisher
-  rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
-  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
-  pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>("/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
-  pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
+    // Publishers
+    // In intra process communication, we cant use transient local,
+    // so we disable the intra process for this publisher
+    rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
+    options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+    pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>(
+        "/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
+    pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
 
-  // Services
-  restart_srv_ = this->create_service<std_srvs::srv::Trigger>(
-    name_ + "/restart", std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
-  pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(
-    name_ + "/pause_img_pub", std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
-  release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(
-    name_ + "/release", std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
-  grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
-    name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
-  is_camera_focused_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    // Services
+    restart_srv_ = this->create_service<std_srvs::srv::Trigger>(name_ + "/restart",
+                                                                std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
+    pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/pause_img_pub",
+                                                                  std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
+    release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/release",
+                                                                    std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
+    grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
+        name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
+    is_camera_focused_srv_ = this->create_service<std_srvs::srv::SetBool>(
         name_ + "/is_focused", std::bind(&Driver::isCameraFocusedCb, this, _1, _2, _3));
 
-  params_callback_handle_ =
-    this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
+    params_callback_handle_ = this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
 }
 
 bool Driver::setup()
 {
+    camera_.reset(new Capture(shared_from_this(), "/video_mapping" + name_ + "/image_raw",
+                              "/video_mapping" + name_ + "/camera_info", "/video_mapping" + name_ + "/image_rect",
+                              frame_id_, roi_exposure_, PUBLISHER_BUFFER_SIZE));
 
-  camera_.reset(new Capture(shared_from_this(),
-                            "/video_mapping" + name_ + "/image_raw",
-                            "/video_mapping" + name_ + "/camera_info",
-                            "/video_mapping" + name_ + "/image_rect",
-                            frame_id_,
-                            roi_exposure_,
-                            PUBLISHER_BUFFER_SIZE));
-
-  if (video_path_ != "")
-  {
-    camera_->openFile(video_path_);
-  }
-  else if (device_id_ >= 0)
-  {
-    if (!camera_->open(device_id_))
+    if (video_path_ != "")
     {
-      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
-      return false;
+        camera_->openFile(video_path_);
     }
-  }
-  else if (port_ != "")
-  {
-    if (!camera_->open(port_))
+    else if (device_id_ >= 0)
     {
-      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
-      return false;
+        if (!camera_->open(device_id_))
+        {
+            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
+            return false;
+        }
     }
-  }
+    else if (port_ != "")
+    {
+        if (!camera_->open(port_))
+        {
+            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
+            return false;
+        }
+    }
 
-  camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
-  camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
-  camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
-  camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-  camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-  camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-  camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-  camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-  camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-  camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
-  camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
-  camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
+    camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
+    camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
+    camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
+    camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+    camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+    camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+    camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+    camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+    camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+    camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
+    camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
+    camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
 #ifdef CV_CAP_PROP_WHITE_BALANCE_U
     camera_->setPropertyFromParam(cv::CAP_PROP_WHITE_BALANCE_U, "cv_cap_prop_white_balance_u");
 #endif  // CV_CAP_PROP_WHITE_BALANCE_U
@@ -155,155 +149,156 @@ bool Driver::setup()
     camera_->setPropertyFromParam(cv::CAP_PROP_BUFFERSIZE, "cv_cap_prop_buffersize");
 #endif  // CV_CAP_PROP_BUFFERSIZE
 
-  // Timers
-  read_tmr_ =
-    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
-  publish_tmr_ =
-    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)), std::bind(&Driver::proceed, this));
-  update_resolution_tmr_ =
-    this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
-  update_resolution_tmr_->cancel();
+    // Timers
+    read_tmr_ =
+        this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
+    publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
+                                           std::bind(&Driver::proceed, this));
+    update_resolution_tmr_ =
+        this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
+    update_resolution_tmr_->cancel();
 
-  cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
-  cam_status_->data = ONLINE;
-  pub_cam_status_->publish(*cam_status_);
-  publish_diagnostic(ONLINE);
-
-  // set error image
-  std::stringstream error_msg;
-  auto upper_label = str_toupper(name_.c_str());
-  error_msg << upper_label << " CONNECTING...";
-  camera_->set_error_image(error_msg.str());
-
-  // Log camera starting configuration
-  aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
-  // Update resolution to make sure it's set correctly
-  update_resolution();
-  RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
-              name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
-              int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_), int(camera_->getProperty(cv::CAP_PROP_FPS)),
-              float(camera_->getProperty(cv::CAP_PROP_FOURCC)), int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
-  return true;
-}
-
-void Driver::read()
-{
-  if (!camera_->is_opened()) return;
-
-  if (!camera_->grab())
-  {
-    camera_->close();
-  }
-}
-
-void Driver::proceed()
-{
-  if (video_path_ != "") camera_->capture(flip_vertical_, flip_horizontal_);
-
-  else if (!camera_->is_opened())
-  {
-    read_tmr_->cancel();
-
-    if (reconnection_routine_) 
-    {
-      // set error image
-      std::stringstream error_msg;
-      auto upper_label = str_toupper(name_.c_str());
-      error_msg << upper_label << " " << status_map_[DISCONNECTED];
-      camera_->set_error_image(error_msg.str());
-
-      cam_status_->data = DISCONNECTED;
-      pub_cam_status_->publish(*cam_status_);
-      publish_diagnostic(DISCONNECTED);
-
-      attempt_reconnection();
-    }
-    else
-    {
-      RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-      camera_->close();
-      cam_status_->data = LOST;
-      pub_cam_status_->publish(*cam_status_);
-      publish_diagnostic(LOST);
-
-      // set error image
-      std::stringstream error_msg;
-      auto upper_label = str_toupper(name_.c_str());
-      error_msg << upper_label << " CAMERA " << status_map_[LOST];
-      camera_->set_error_image(error_msg.str());
-
-      publish_tmr_->cancel();
-    }
-  }
-  else
-  {
-    if (!camera_->capture(flip_vertical_, flip_horizontal_))
-    {
-      RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
-    }
-    else
-    {
-      if (always_rectify_ || (rectify_ && undistort_img_req_bool_))
-        camera_->rectify();
-    }
-  }
-}
-
-void Driver::attempt_reconnection()
-{
-  while (reconnection_attempts_ < video_stream_recovery_tries_)
-  {
-    RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
-                video_stream_recovery_tries_);
-    if (camera_->open(port_))
-    {
-      if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
-      {
-        read_tmr_->reset();
-        RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
-        reconnection_attempts_ = 0;
-        cam_status_->data = ONLINE;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(ONLINE);
-        return;
-      }
-      else
-      {
-        // set error image
-        std::stringstream error_msg;
-        auto upper_label = str_toupper(name_.c_str());
-        error_msg << upper_label << " " << status_map_[READING_ERROR];
-        camera_->set_error_image(error_msg.str());
-
-        cam_status_->data = READING_ERROR;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(READING_ERROR);
-      }
-    }
-    std::stringstream error_msg;
-    auto upper_label = str_toupper(name_.c_str());
-    error_msg << upper_label << " " << status_map_[DISCONNECTED];
-    camera_->set_error_image(error_msg.str());
-    reconnection_attempts_++;
-    std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
-  }
-  if (reconnection_attempts_ >= video_stream_recovery_tries_)
-  {
-    RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-    camera_->close();
-    cam_status_->data = LOST;
+    cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
+    cam_status_->data = ONLINE;
     pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(LOST);
+    publish_diagnostic(ONLINE);
 
     // set error image
     std::stringstream error_msg;
     auto upper_label = str_toupper(name_.c_str());
-    error_msg << upper_label << " CAMERA " << status_map_[LOST];
+    error_msg << upper_label << " CONNECTING...";
     camera_->set_error_image(error_msg.str());
 
-    read_tmr_->cancel();
-    publish_tmr_->cancel();
-  }
+    // Log camera starting configuration
+    aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
+    // Update resolution to make sure it's set correctly
+    update_resolution();
+    RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
+                name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
+                int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_),
+                int(camera_->getProperty(cv::CAP_PROP_FPS)), float(camera_->getProperty(cv::CAP_PROP_FOURCC)),
+                int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
+    return true;
+}
+
+void Driver::read()
+{
+    if (!camera_->is_opened()) return;
+
+    if (!camera_->grab())
+    {
+        camera_->close();
+    }
+}
+
+void Driver::proceed()
+{
+    if (video_path_ != "")
+        camera_->capture(flip_vertical_, flip_horizontal_);
+
+    else if (!camera_->is_opened())
+    {
+        read_tmr_->cancel();
+
+        if (reconnection_routine_)
+        {
+            // set error image
+            std::stringstream error_msg;
+            auto upper_label = str_toupper(name_.c_str());
+            error_msg << upper_label << " " << status_map_[DISCONNECTED];
+            camera_->set_error_image(error_msg.str());
+
+            cam_status_->data = DISCONNECTED;
+            pub_cam_status_->publish(*cam_status_);
+            publish_diagnostic(DISCONNECTED);
+
+            attempt_reconnection();
+        }
+        else
+        {
+            RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+            camera_->close();
+            cam_status_->data = LOST;
+            pub_cam_status_->publish(*cam_status_);
+            publish_diagnostic(LOST);
+
+            // set error image
+            std::stringstream error_msg;
+            auto upper_label = str_toupper(name_.c_str());
+            error_msg << upper_label << " CAMERA " << status_map_[LOST];
+            camera_->set_error_image(error_msg.str());
+
+            publish_tmr_->cancel();
+        }
+    }
+    else
+    {
+        if (!camera_->capture(flip_vertical_, flip_horizontal_))
+        {
+            RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
+        }
+        else
+        {
+            if (always_rectify_ || (rectify_ && undistort_img_req_bool_)) camera_->rectify();
+        }
+    }
+}
+
+void Driver::attempt_reconnection()
+{
+    while (reconnection_attempts_ < video_stream_recovery_tries_)
+    {
+        RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
+                    video_stream_recovery_tries_);
+        if (camera_->open(port_))
+        {
+            if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
+            {
+                read_tmr_->reset();
+                RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
+                reconnection_attempts_ = 0;
+                cam_status_->data = ONLINE;
+                pub_cam_status_->publish(*cam_status_);
+                publish_diagnostic(ONLINE);
+                return;
+            }
+            else
+            {
+                // set error image
+                std::stringstream error_msg;
+                auto upper_label = str_toupper(name_.c_str());
+                error_msg << upper_label << " " << status_map_[READING_ERROR];
+                camera_->set_error_image(error_msg.str());
+
+                cam_status_->data = READING_ERROR;
+                pub_cam_status_->publish(*cam_status_);
+                publish_diagnostic(READING_ERROR);
+            }
+        }
+        std::stringstream error_msg;
+        auto upper_label = str_toupper(name_.c_str());
+        error_msg << upper_label << " " << status_map_[DISCONNECTED];
+        camera_->set_error_image(error_msg.str());
+        reconnection_attempts_++;
+        std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
+    }
+    if (reconnection_attempts_ >= video_stream_recovery_tries_)
+    {
+        RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+        camera_->close();
+        cam_status_->data = LOST;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(LOST);
+
+        // set error image
+        std::stringstream error_msg;
+        auto upper_label = str_toupper(name_.c_str());
+        error_msg << upper_label << " CAMERA " << status_map_[LOST];
+        camera_->set_error_image(error_msg.str());
+
+        read_tmr_->cancel();
+        publish_tmr_->cancel();
+    }
 }
 
 rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
@@ -311,308 +306,296 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
     auto result = param_manager_.parametersCb(parameters);
     /* Some extra logic after catch the new values if you need it */
     // reset the timer if publishing rate changed
-    for (auto parameter : parameters) {
-    const auto & type = parameter.get_type();
-    const auto & name = parameter.get_name();
+    for (auto parameter : parameters)
+    {
+        const auto& type = parameter.get_type();
+        const auto& name = parameter.get_name();
 
-    if (type == rclcpp::ParameterType::PARAMETER_DOUBLE) 
-    {
-      if (name == "read_rate") 
-      {
-        read_rate_ = parameter.as_double();
-        // Create timer with new read rate
-        RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
-        read_tmr_->cancel();
-        read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), 
-                                  std::bind(&Driver::read, this));
-      } 
-      else if (name  == "publish_rate") 
-      {
-        publish_rate_ = parameter.as_double();
-        // Create timer with new publish rate
-        RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
-        publish_tmr_->cancel();
-        publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
-                                               std::bind(&Driver::proceed, this));
-      }
-      else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-      }
-      else if (name == "cv_cap_prop_brightness")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-      }
-      else if (name == "cv_cap_prop_contrast")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-      }
-      else if (name == "cv_cap_prop_saturation")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-      }
-      else if (name == "cv_cap_prop_hue")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-      }
-      else if (name == "cv_cap_prop_gain")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-      }
-      else if (name == "cv_cap_prop_exposure")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-      }
-      else if (name == "cv_cap_prop_exposure")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-      }
-      else if (name == "cv_cap_prop_auto_exposure")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
-      }
-    }
-    else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
-    {
-      if (name == "width")
-      {
-        width_ = parameter.as_int();
-        // update height to maintain aspect ratio
-        height_ = int(width_ / aspect_ratio_);
-        RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio", parameter.as_int(), height_);
-        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-        // so we need to reset the timer to update the resolution
-        update_resolution_tmr_->reset();
-      }
-      else if (name == "height")
-      {
-        height_ = parameter.as_int();
-        // update width to maintain aspect ratio
-        width_ = int(height_ * aspect_ratio_);
-        RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio", parameter.as_int(), width_);
-        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-        // so we need to reset the timer to update the resolution
-        update_resolution_tmr_->reset();
-      }
-    }
-    else if (type == rclcpp::ParameterType::PARAMETER_STRING)
-    {
-      if (name == "intrinsic_file")
-      {
-        camera_->loadCameraInfo();
-      }
-    }
-    else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
-    {
-      if (name == "roi_exposure")
-      {
-        roi_exposure_ = parameter.as_bool();
-        setup();
-      }
-      else if (name == "always_publish")
-      {
-        always_publish_ = parameter.as_bool();
-        if (cam_status_->data == PAUSED && always_publish_)
+        if (type == rclcpp::ParameterType::PARAMETER_DOUBLE)
         {
-          read_tmr_->reset();
-          publish_tmr_->reset();
-          cam_status_->data = ONLINE;
-          pub_cam_status_->publish(*cam_status_);
-          publish_diagnostic(ONLINE);
+            if (name == "read_rate")
+            {
+                read_rate_ = parameter.as_double();
+                // Create timer with new read rate
+                RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
+                read_tmr_->cancel();
+                read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)),
+                                                    std::bind(&Driver::read, this));
+            }
+            else if (name == "publish_rate")
+            {
+                publish_rate_ = parameter.as_double();
+                // Create timer with new publish rate
+                RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
+                publish_tmr_->cancel();
+                publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
+                                                       std::bind(&Driver::proceed, this));
+            }
+            else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+            }
+            else if (name == "cv_cap_prop_brightness")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+            }
+            else if (name == "cv_cap_prop_contrast")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+            }
+            else if (name == "cv_cap_prop_saturation")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+            }
+            else if (name == "cv_cap_prop_hue")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+            }
+            else if (name == "cv_cap_prop_gain")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+            }
+            else if (name == "cv_cap_prop_exposure")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+            }
+            else if (name == "cv_cap_prop_exposure")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+            }
+            else if (name == "cv_cap_prop_auto_exposure")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
+            }
         }
-      }
+        else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
+        {
+            if (name == "width")
+            {
+                width_ = parameter.as_int();
+                // update height to maintain aspect ratio
+                height_ = int(width_ / aspect_ratio_);
+                RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio",
+                            parameter.as_int(), height_);
+                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+                // so we need to reset the timer to update the resolution
+                update_resolution_tmr_->reset();
+            }
+            else if (name == "height")
+            {
+                height_ = parameter.as_int();
+                // update width to maintain aspect ratio
+                width_ = int(height_ * aspect_ratio_);
+                RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio",
+                            parameter.as_int(), width_);
+                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+                // so we need to reset the timer to update the resolution
+                update_resolution_tmr_->reset();
+            }
+        }
+        else if (type == rclcpp::ParameterType::PARAMETER_STRING)
+        {
+            if (name == "intrinsic_file")
+            {
+                camera_->loadCameraInfo();
+            }
+        }
+        else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
+        {
+            if (name == "roi_exposure")
+            {
+                roi_exposure_ = parameter.as_bool();
+                setup();
+            }
+            else if (name == "always_publish")
+            {
+                always_publish_ = parameter.as_bool();
+                if (cam_status_->data == PAUSED && always_publish_)
+                {
+                    read_tmr_->reset();
+                    publish_tmr_->reset();
+                    cam_status_->data = ONLINE;
+                    pub_cam_status_->publish(*cam_status_);
+                    publish_diagnostic(ONLINE);
+                }
+            }
+        }
     }
-  }
     return result;
 }
 
 void Driver::RestartNodeCb(shared_ptr_request_id const, shared_ptr_trigger_request const,
-                          shared_ptr_trigger_response response)
+                           shared_ptr_trigger_response response)
 {
-  RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
-  reconnection_attempts_ = 0;
-  setup();
-  response->success = true;
-  response->message = "Camera setup will be restarted";
+    RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
+    reconnection_attempts_ = 0;
+    setup();
+    response->success = true;
+    response->message = "Camera setup will be restarted";
 }
 
 void Driver::update_resolution()
 {
-  update_resolution_tmr_->cancel();
-  if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
-  {
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-    camera_->rescaleCameraInfo(width_, height_);
-  }
-  if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
-  {
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-    camera_->rescaleCameraInfo(width_, height_);
-  }
+    update_resolution_tmr_->cancel();
+    if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
+    {
+        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+        camera_->rescaleCameraInfo(width_, height_);
+    }
+    if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
+    {
+        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+        camera_->rescaleCameraInfo(width_, height_);
+    }
 }
 
 void Driver::GrabFrameCb(shared_ptr_request_id const, shared_ptr_grab_frame_request const,
-                          shared_ptr_grab_frame_response response)
+                         shared_ptr_grab_frame_response response)
 {
-  // The sensor has a buffer so we need to grab several times to get the current image.
-  for (int i = 0; i <= 5; i++)
-  {
-    if (!camera_->grab())
+    // The sensor has a buffer so we need to grab several times to get the current image.
+    for (int i = 0; i <= 5; i++)
     {
-      response->success = false;
-      response->message = "Failed to grab frame from camera.";
-      return;
+        if (!camera_->grab())
+        {
+            response->success = false;
+            response->message = "Failed to grab frame from camera.";
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-  if (!camera_->capture(flip_vertical_, flip_horizontal_))
-  {
-    response->success = false;
-    response->message = "Failed to capture frame from camera.";
+    if (!camera_->capture(flip_vertical_, flip_horizontal_))
+    {
+        response->success = false;
+        response->message = "Failed to capture frame from camera.";
+        return;
+    }
+    response->frame = *camera_->getImageMsgPtr();
+    response->success = true;
+    response->message = "Successfully got frame!";
+    RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
     return;
-  }
-  response->frame = *camera_->getImageMsgPtr();
-  response->success = true;
-  response->message = "Successfully got frame!";
-  RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
-  return;
 }
 
 void Driver::isCameraFocusedCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
                                shared_ptr_bool_response response)
 {
-    // Check if camera frame is available
-    if (camera_->getCvImage().empty())
+    if (!camera_)
+    {
+        response->success = false;
+        response->message = "Camera not initialized";
+        return;
+    }
+    if (camera_->is_empty())
     {
         response->success = false;
         response->message = "Camera frame is empty";
         return;
     }
-
-    // Calculate image focus using Laplacian variance method
-    // Higher variance indicates more edges/details are in focus
-    cv::Mat frame = camera_->getCvImage();
-    cv::Mat gray, laplacian;
-    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);  // Convert to grayscale
-    cv::Laplacian(gray, laplacian, CV_64F);         // Apply Laplacian filter
-
-    cv::Scalar mean, stddev;
-    cv::meanStdDev(laplacian, mean, stddev);  // Calculate mean and standard deviation
-
-    double variance = stddev[0] * stddev[0];  // Calculate variance
-
-    // Threshold to determine if the camera is focused
-    // Note: In the original code, variance < threshold means unfocused
-    // But here we're checking if it's focused, so we invert the logic
-    bool is_focused = variance >= focus_threshold_;
-
-    response->success = is_focused;
-    response->message = "Variance: " + std::to_string(variance);  // Return the variance value in the message
+    response->success = camera_->isFocused();
+    response->message = std::string("Camera is ") + (response->success ? "focused" : "not focused");
     return;
 }
 
 void Driver::PauseImageCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                            shared_ptr_bool_response response)
+                          shared_ptr_bool_response response)
 {
-  if (request->data && !always_publish_)
-  {
-    read_tmr_->cancel();
-    publish_tmr_->cancel();
-    cam_status_->data = PAUSED;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(PAUSED);
-    response->success = true;
-    response->message = "Camera read and pub paused";
-    return;
-  }
-  else if (cam_status_->data == PAUSED)
-  {
-    read_tmr_->reset();
-    publish_tmr_->reset();
-    cam_status_->data = ONLINE;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(ONLINE);
-    response->success = true;
-    response->message = "Camera read and pub resumed";
-    return;
-  }
+    if (request->data && !always_publish_)
+    {
+        read_tmr_->cancel();
+        publish_tmr_->cancel();
+        cam_status_->data = PAUSED;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(PAUSED);
+        response->success = true;
+        response->message = "Camera read and pub paused";
+        return;
+    }
+    else if (cam_status_->data == PAUSED)
+    {
+        read_tmr_->reset();
+        publish_tmr_->reset();
+        cam_status_->data = ONLINE;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(ONLINE);
+        response->success = true;
+        response->message = "Camera read and pub resumed";
+        return;
+    }
 }
 
-
 void Driver::ReleaseCamCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                            shared_ptr_bool_response response)
+                          shared_ptr_bool_response response)
 {
-  if (request->data)
-  {
-    read_tmr_->cancel();
-    publish_tmr_->cancel();
-    camera_->close();
-    cam_status_->data = TURNED_OFF;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(TURNED_OFF);
-    response->success = true;
-    response->message = "Camera device released";
-    return;
-  }
-  else
-  {
-    setup();
-    read_tmr_->reset();
-    publish_tmr_->reset();
-    cam_status_->data = ONLINE;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(ONLINE);
-    response->success = true;
-    response->message = "Camera read and pub resumed";
-    return;
-  }
+    if (request->data)
+    {
+        read_tmr_->cancel();
+        publish_tmr_->cancel();
+        camera_->close();
+        cam_status_->data = TURNED_OFF;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(TURNED_OFF);
+        response->success = true;
+        response->message = "Camera device released";
+        return;
+    }
+    else
+    {
+        setup();
+        read_tmr_->reset();
+        publish_tmr_->reset();
+        cam_status_->data = ONLINE;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(ONLINE);
+        response->success = true;
+        response->message = "Camera read and pub resumed";
+        return;
+    }
 }
 void Driver::publish_diagnostic(Status status)
 {
-  auto message = diagnostic_msgs::msg::DiagnosticArray();
-  message.header.stamp = this->get_clock()->now();
-  auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
-  status_msg.name = "USB Camera Status";
-  status_msg.hardware_id = "/USB" + name_;
+    auto message = diagnostic_msgs::msg::DiagnosticArray();
+    message.header.stamp = this->get_clock()->now();
+    auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
+    status_msg.name = "USB Camera Status";
+    status_msg.hardware_id = "/USB" + name_;
 
-  switch (status) {
-    case ONLINE:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-        status_msg.message = "Camera is online";
-        break;
-    case DISCONNECTED:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Camera is disconnected";
-        break;
-    case LOST:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-        status_msg.message = "Camera lost";
-        break;
-    case READING_ERROR:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Reading error from camera";
-        break;
-    case PAUSED:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Camera is paused";
-        break;
-    case TURNED_OFF:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Camera is turned off";
-        break;
-    default:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-        status_msg.message = "Unrecognized camera status";
-  }
+    switch (status)
+    {
+        case ONLINE:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+            status_msg.message = "Camera is online";
+            break;
+        case DISCONNECTED:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Camera is disconnected";
+            break;
+        case LOST:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+            status_msg.message = "Camera lost";
+            break;
+        case READING_ERROR:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Reading error from camera";
+            break;
+        case PAUSED:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Camera is paused";
+            break;
+        case TURNED_OFF:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Camera is turned off";
+            break;
+        default:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+            status_msg.message = "Unrecognized camera status";
+    }
 
-  message.status.push_back(status_msg);
-  pub_cam_diagnostic_->publish(message);
+    message.status.push_back(status_msg);
+    pub_cam_diagnostic_->publish(message);
 }
 
-Driver::~Driver()
-{
-}
+Driver::~Driver() {}
 
 }  // namespace cv_camera
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -3,145 +3,141 @@
 #include "cv_camera/driver.h"
 #include <string>
 
-namespace
-{
+namespace {
 const double DEFAULT_RATE = 30.0;
 const int32_t PUBLISHER_BUFFER_SIZE = 1;
-}
+}  // namespace
 
-namespace cv_camera
-{
+namespace cv_camera {
 
 Driver::Driver(const rclcpp::NodeOptions& options) : Node("cv_camera", options)
 {
-  auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
-  this->parameters_setup();
-  this->setup();
+    auto ptr = std::shared_ptr<Driver>(this, [](Driver*) {});
+    this->parameters_setup();
+    this->setup();
 }
 
 void Driver::parameters_setup()
 {
-  name_ = this->get_fully_qualified_name();
+    name_ = this->get_fully_qualified_name();
 
-  // OpenCV Parameters
-  this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
-  this->declare_parameter("cv_cap_prop_fourcc", 0.0);
-  this->get_parameter("fourcc", fourcc_);
-  // Decode fourcc as CV2 only accepts double values for its parameters
-  this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc", (double)cv::VideoWriter::fourcc(
-                      *fourcc_[0].c_str(), *fourcc_[1].c_str(), *fourcc_[2].c_str(), *fourcc_[3].c_str())));
+    // OpenCV Parameters
+    this->declare_parameter("fourcc", rclcpp::PARAMETER_STRING_ARRAY);
+    this->declare_parameter("cv_cap_prop_fourcc", 0.0);
+    this->get_parameter("fourcc", fourcc_);
+    // Decode fourcc as CV2 only accepts double values for its parameters
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_fourcc",
+                                          (double)cv::VideoWriter::fourcc(*fourcc_[0].c_str(), *fourcc_[1].c_str(),
+                                                                          *fourcc_[2].c_str(), *fourcc_[3].c_str())));
 
-  // Environment Variables | ROS Parameters
-  param_manager_ = NodeParamManager(this);
-  param_manager_.addParameter<std::string>(port_, "port", "");
-  param_manager_.addParameter(device_id_, "device_id", -1);
-  param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
-  param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
-  param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
-  param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
-  param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
-  param_manager_.addParameter(rectify_, "rectify", false);
-  param_manager_.addParameter(always_rectify_, "always_rectify", false);
-  param_manager_.addParameter(always_publish_, "always_publish", false);
-  param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
-  param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
-  param_manager_.addParameter<std::string>(video_path_, "video_path", "");
-  param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
-  param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
-  param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
+    // Environment Variables | ROS Parameters
+    param_manager_ = NodeParamManager(this);
+    param_manager_.addParameter<std::string>(port_, "port", "");
+    param_manager_.addParameter(device_id_, "device_id", -1);
+    param_manager_.addParameter(publish_rate_, "publish_rate", 15.0f);
+    param_manager_.addParameter(read_rate_, "read_rate", 15.0f);
+    param_manager_.addParameter(flip_vertical_, "flip_vertical", false);
+    param_manager_.addParameter(flip_horizontal_, "flip_horizontal", false);
+    param_manager_.addParameter(roi_exposure_, "roi_exposure", false);
+    param_manager_.addParameter(rectify_, "rectify", false);
+    param_manager_.addParameter(always_rectify_, "always_rectify", false);
+    param_manager_.addParameter(always_publish_, "always_publish", false);
+    param_manager_.addParameter(reconnection_routine_, "reconnection_routine");
+    param_manager_.addParameter<std::string>(intrinsic_file_, "intrinsic_file", "");
+    param_manager_.addParameter<std::string>(video_path_, "video_path", "");
+    param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
+    param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
+    param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
+    param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
 
-  // Video capture parameters
-  param_manager_.addParameter(width_, "width", 640);
-  param_manager_.addParameter(height_, "height", 360);
-  this->declare_parameter("cv_cap_prop_frame_width", 640.0);
-  this->declare_parameter("cv_cap_prop_frame_height", 360.0);
-  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-  this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-  param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
-  param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
-  param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
-  param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
-  param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
-  param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
-  param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
+    // Video capture parameters
+    param_manager_.addParameter(width_, "width", 640);
+    param_manager_.addParameter(height_, "height", 360);
+    this->declare_parameter("cv_cap_prop_frame_width", 640.0);
+    this->declare_parameter("cv_cap_prop_frame_height", 360.0);
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+    param_manager_.addParameter(cv_cap_prop_brightness_, "cv_cap_prop_brightness", 0.0f);
+    param_manager_.addParameter(cv_cap_prop_contrast_, "cv_cap_prop_contrast", 32.0f);
+    param_manager_.addParameter(cv_cap_prop_saturation_, "cv_cap_prop_saturation", 56.0f);
+    param_manager_.addParameter(cv_cap_prop_hue_, "cv_cap_prop_hue", 0.0f);
+    param_manager_.addParameter(cv_cap_prop_gain_, "cv_cap_prop_gain", 0.0f);
+    param_manager_.addParameter(cv_cap_prop_exposure_, "cv_cap_prop_exposure", 156.0f);
+    param_manager_.addParameter(cv_cap_prop_auto_exposure_, "cv_cap_prop_auto_exposure", 3.0f);
 
-  // Subscribers
-  undistort_req_sub_ = 
-    this->create_subscription<std_msgs::msg::Bool>("/video_mapping/un_distort", 1, 
-                    [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
+    // Subscribers
+    undistort_req_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+        "/video_mapping/un_distort", 1,
+        [&](const std_msgs::msg::Bool::SharedPtr msg) -> void { undistort_img_req_bool_ = msg->data; });
 
-  // Publishers
-  // In intra process communication, we cant use transient local,
-  // so we disable the intra process for this publisher
-  rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
-  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
-  pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>("/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
-  pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
+    // Publishers
+    // In intra process communication, we cant use transient local,
+    // so we disable the intra process for this publisher
+    rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> options;
+    options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+    pub_cam_status_ = this->create_publisher<std_msgs::msg::UInt8>(
+        "/video_mapping" + name_ + "/status", rclcpp::QoS(1).keep_all().transient_local().reliable(), options);
+    pub_cam_diagnostic_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
 
-  // Services
-  restart_srv_ = this->create_service<std_srvs::srv::Trigger>(
-    name_ + "/restart", std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
-  pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(
-    name_ + "/pause_img_pub", std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
-  release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(
-    name_ + "/release", std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
-  grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
-    name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
-
-  params_callback_handle_ =
-    this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
+    // Services
+    restart_srv_ = this->create_service<std_srvs::srv::Trigger>(name_ + "/restart",
+                                                                std::bind(&Driver::RestartNodeCb, this, _1, _2, _3));
+    pause_img_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/pause_img_pub",
+                                                                  std::bind(&Driver::PauseImageCb, this, _1, _2, _3));
+    release_cam_srv_ = this->create_service<std_srvs::srv::SetBool>(name_ + "/release",
+                                                                    std::bind(&Driver::ReleaseCamCb, this, _1, _2, _3));
+    grab_frame_srv_ = this->create_service<cv_camera::srv::GrabFrame>(
+        name_ + "/grab_frame", std::bind(&Driver::GrabFrameCb, this, _1, _2, _3));
+    is_camera_focused_srv_ = this->create_service<std_srvs::srv::SetBool>(
+        name_ + "/is_focused", std::bind(&Driver::isCameraFocusedCb, this, _1, _2, _3));
+    params_callback_handle_ = this->add_on_set_parameters_callback(std::bind(&Driver::parameters_cb, this, _1));
 }
 
 bool Driver::setup()
 {
+    camera_.reset(new Capture(shared_from_this(), "/video_mapping" + name_ + "/image_raw",
+                              "/video_mapping" + name_ + "/camera_info", "/video_mapping" + name_ + "/image_rect",
+                              frame_id_, roi_exposure_, PUBLISHER_BUFFER_SIZE));
 
-  camera_.reset(new Capture(shared_from_this(),
-                            "/video_mapping" + name_ + "/image_raw",
-                            "/video_mapping" + name_ + "/camera_info",
-                            "/video_mapping" + name_ + "/image_rect",
-                            frame_id_,
-                            roi_exposure_,
-                            PUBLISHER_BUFFER_SIZE));
-
-  if (video_path_ != "")
-  {
-    camera_->openFile(video_path_);
-  }
-  else if (device_id_ >= 0)
-  {
-    if (!camera_->open(device_id_))
+    if (video_path_ != "")
     {
-      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
-      return false;
+        camera_->openFile(video_path_);
     }
-  }
-  else if (port_ != "")
-  {
-    if (!camera_->open(port_))
+    else if (device_id_ >= 0)
     {
-      RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
-      return false;
+        if (!camera_->open(device_id_))
+        {
+            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by device_id [%d]", name_.c_str(), device_id_);
+            return false;
+        }
     }
-  }
+    else if (port_ != "")
+    {
+        if (!camera_->open(port_))
+        {
+            RCLCPP_WARN(get_logger(), "[%s] Couldn't open camera by port [%s]", name_.c_str(), port_.c_str());
+            return false;
+        }
+    }
 
-  camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
-  camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
-  camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
-  camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-  camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-  camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-  camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-  camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-  camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-  camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
-  camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
-  camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
+    camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
+    camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
+    camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
+    camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");
+    camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+    camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+    camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+    camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+    camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+    camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+    camera_->setPropertyFromParam(cv::CAP_PROP_CONVERT_RGB, "cv_cap_prop_convert_rgb");
+    camera_->setPropertyFromParam(cv::CAP_PROP_RECTIFICATION, "cv_cap_prop_rectification");
+    camera_->setPropertyFromParam(cv::CAP_PROP_ISO_SPEED, "cv_cap_prop_iso_speed");
 #ifdef CV_CAP_PROP_WHITE_BALANCE_U
     camera_->setPropertyFromParam(cv::CAP_PROP_WHITE_BALANCE_U, "cv_cap_prop_white_balance_u");
 #endif  // CV_CAP_PROP_WHITE_BALANCE_U
@@ -152,155 +148,156 @@ bool Driver::setup()
     camera_->setPropertyFromParam(cv::CAP_PROP_BUFFERSIZE, "cv_cap_prop_buffersize");
 #endif  // CV_CAP_PROP_BUFFERSIZE
 
-  // Timers
-  read_tmr_ =
-    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
-  publish_tmr_ =
-    this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)), std::bind(&Driver::proceed, this));
-  update_resolution_tmr_ =
-    this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
-  update_resolution_tmr_->cancel();
+    // Timers
+    read_tmr_ =
+        this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), std::bind(&Driver::read, this));
+    publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
+                                           std::bind(&Driver::proceed, this));
+    update_resolution_tmr_ =
+        this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&Driver::update_resolution, this));
+    update_resolution_tmr_->cancel();
 
-  cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
-  cam_status_->data = ONLINE;
-  pub_cam_status_->publish(*cam_status_);
-  publish_diagnostic(ONLINE);
-
-  // set error image
-  std::stringstream error_msg;
-  auto upper_label = str_toupper(name_.c_str());
-  error_msg << upper_label << " CONNECTING...";
-  camera_->set_error_image(error_msg.str());
-
-  // Log camera starting configuration
-  aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
-  // Update resolution to make sure it's set correctly
-  update_resolution();
-  RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
-              name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
-              int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_), int(camera_->getProperty(cv::CAP_PROP_FPS)),
-              float(camera_->getProperty(cv::CAP_PROP_FOURCC)), int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
-  return true;
-}
-
-void Driver::read()
-{
-  if (!camera_->is_opened()) return;
-
-  if (!camera_->grab())
-  {
-    camera_->close();
-  }
-}
-
-void Driver::proceed()
-{
-  if (video_path_ != "") camera_->capture(flip_vertical_, flip_horizontal_);
-
-  else if (!camera_->is_opened())
-  {
-    read_tmr_->cancel();
-
-    if (reconnection_routine_) 
-    {
-      // set error image
-      std::stringstream error_msg;
-      auto upper_label = str_toupper(name_.c_str());
-      error_msg << upper_label << " " << status_map_[DISCONNECTED];
-      camera_->set_error_image(error_msg.str());
-
-      cam_status_->data = DISCONNECTED;
-      pub_cam_status_->publish(*cam_status_);
-      publish_diagnostic(DISCONNECTED);
-
-      attempt_reconnection();
-    }
-    else
-    {
-      RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-      camera_->close();
-      cam_status_->data = LOST;
-      pub_cam_status_->publish(*cam_status_);
-      publish_diagnostic(LOST);
-
-      // set error image
-      std::stringstream error_msg;
-      auto upper_label = str_toupper(name_.c_str());
-      error_msg << upper_label << " CAMERA " << status_map_[LOST];
-      camera_->set_error_image(error_msg.str());
-
-      publish_tmr_->cancel();
-    }
-  }
-  else
-  {
-    if (!camera_->capture(flip_vertical_, flip_horizontal_))
-    {
-      RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
-    }
-    else
-    {
-      if (always_rectify_ || (rectify_ && undistort_img_req_bool_))
-        camera_->rectify();
-    }
-  }
-}
-
-void Driver::attempt_reconnection()
-{
-  while (reconnection_attempts_ < video_stream_recovery_tries_)
-  {
-    RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
-                video_stream_recovery_tries_);
-    if (camera_->open(port_))
-    {
-      if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
-      {
-        read_tmr_->reset();
-        RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
-        reconnection_attempts_ = 0;
-        cam_status_->data = ONLINE;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(ONLINE);
-        return;
-      }
-      else
-      {
-        // set error image
-        std::stringstream error_msg;
-        auto upper_label = str_toupper(name_.c_str());
-        error_msg << upper_label << " " << status_map_[READING_ERROR];
-        camera_->set_error_image(error_msg.str());
-
-        cam_status_->data = READING_ERROR;
-        pub_cam_status_->publish(*cam_status_);
-        publish_diagnostic(READING_ERROR);
-      }
-    }
-    std::stringstream error_msg;
-    auto upper_label = str_toupper(name_.c_str());
-    error_msg << upper_label << " " << status_map_[DISCONNECTED];
-    camera_->set_error_image(error_msg.str());
-    reconnection_attempts_++;
-    std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
-  }
-  if (reconnection_attempts_ >= video_stream_recovery_tries_)
-  {
-    RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
-    camera_->close();
-    cam_status_->data = LOST;
+    cam_status_ = std::make_shared<std_msgs::msg::UInt8>();
+    cam_status_->data = ONLINE;
     pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(LOST);
+    publish_diagnostic(ONLINE);
 
     // set error image
     std::stringstream error_msg;
     auto upper_label = str_toupper(name_.c_str());
-    error_msg << upper_label << " CAMERA " << status_map_[LOST];
+    error_msg << upper_label << " CONNECTING...";
     camera_->set_error_image(error_msg.str());
 
-    read_tmr_->cancel();
-    publish_tmr_->cancel();
-  }
+    // Log camera starting configuration
+    aspect_ratio_ = camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) / camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT);
+    // Update resolution to make sure it's set correctly
+    update_resolution();
+    RCLCPP_INFO(get_logger(), "(GOT VIDEO) %s: DEVICE: %d - SIZE: %dX%d - RATE: %d/%d - PROP_MODE: %f - EXPOSURE: %d",
+                name_.c_str(), device_id_, int(camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH)),
+                int(camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT)), int(read_rate_),
+                int(camera_->getProperty(cv::CAP_PROP_FPS)), float(camera_->getProperty(cv::CAP_PROP_FOURCC)),
+                int(camera_->getProperty(cv::CAP_PROP_AUTO_EXPOSURE)));
+    return true;
+}
+
+void Driver::read()
+{
+    if (!camera_->is_opened()) return;
+
+    if (!camera_->grab())
+    {
+        camera_->close();
+    }
+}
+
+void Driver::proceed()
+{
+    if (video_path_ != "")
+        camera_->capture(flip_vertical_, flip_horizontal_);
+
+    else if (!camera_->is_opened())
+    {
+        read_tmr_->cancel();
+
+        if (reconnection_routine_)
+        {
+            // set error image
+            std::stringstream error_msg;
+            auto upper_label = str_toupper(name_.c_str());
+            error_msg << upper_label << " " << status_map_[DISCONNECTED];
+            camera_->set_error_image(error_msg.str());
+
+            cam_status_->data = DISCONNECTED;
+            pub_cam_status_->publish(*cam_status_);
+            publish_diagnostic(DISCONNECTED);
+
+            attempt_reconnection();
+        }
+        else
+        {
+            RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+            camera_->close();
+            cam_status_->data = LOST;
+            pub_cam_status_->publish(*cam_status_);
+            publish_diagnostic(LOST);
+
+            // set error image
+            std::stringstream error_msg;
+            auto upper_label = str_toupper(name_.c_str());
+            error_msg << upper_label << " CAMERA " << status_map_[LOST];
+            camera_->set_error_image(error_msg.str());
+
+            publish_tmr_->cancel();
+        }
+    }
+    else
+    {
+        if (!camera_->capture(flip_vertical_, flip_horizontal_))
+        {
+            RCLCPP_WARN(get_logger(), "[%s] Couldn't capture frame", name_.c_str());
+        }
+        else
+        {
+            if (always_rectify_ || (rectify_ && undistort_img_req_bool_)) camera_->rectify();
+        }
+    }
+}
+
+void Driver::attempt_reconnection()
+{
+    while (reconnection_attempts_ < video_stream_recovery_tries_)
+    {
+        RCLCPP_WARN(get_logger(), "[%s] Reconnecting... attempt %d/%d", name_.c_str(), reconnection_attempts_ + 1,
+                    video_stream_recovery_tries_);
+        if (camera_->open(port_))
+        {
+            if (camera_->grab() && camera_->capture(flip_vertical_, flip_horizontal_))
+            {
+                read_tmr_->reset();
+                RCLCPP_WARN(get_logger(), "[%s] Reconnected", name_.c_str());
+                reconnection_attempts_ = 0;
+                cam_status_->data = ONLINE;
+                pub_cam_status_->publish(*cam_status_);
+                publish_diagnostic(ONLINE);
+                return;
+            }
+            else
+            {
+                // set error image
+                std::stringstream error_msg;
+                auto upper_label = str_toupper(name_.c_str());
+                error_msg << upper_label << " " << status_map_[READING_ERROR];
+                camera_->set_error_image(error_msg.str());
+
+                cam_status_->data = READING_ERROR;
+                pub_cam_status_->publish(*cam_status_);
+                publish_diagnostic(READING_ERROR);
+            }
+        }
+        std::stringstream error_msg;
+        auto upper_label = str_toupper(name_.c_str());
+        error_msg << upper_label << " " << status_map_[DISCONNECTED];
+        camera_->set_error_image(error_msg.str());
+        reconnection_attempts_++;
+        std::this_thread::sleep_for(std::chrono::seconds(video_stream_recovery_time_));
+    }
+    if (reconnection_attempts_ >= video_stream_recovery_tries_)
+    {
+        RCLCPP_ERROR(get_logger(), "[%s] Camera lost", name_.c_str());
+        camera_->close();
+        cam_status_->data = LOST;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(LOST);
+
+        // set error image
+        std::stringstream error_msg;
+        auto upper_label = str_toupper(name_.c_str());
+        error_msg << upper_label << " CAMERA " << status_map_[LOST];
+        camera_->set_error_image(error_msg.str());
+
+        read_tmr_->cancel();
+        publish_tmr_->cancel();
+    }
 }
 
 rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector<rclcpp::Parameter>& parameters)
@@ -308,275 +305,309 @@ rcl_interfaces::msg::SetParametersResult Driver::parameters_cb(const std::vector
     auto result = param_manager_.parametersCb(parameters);
     /* Some extra logic after catch the new values if you need it */
     // reset the timer if publishing rate changed
-    for (auto parameter : parameters) {
-    const auto & type = parameter.get_type();
-    const auto & name = parameter.get_name();
+    for (auto parameter : parameters)
+    {
+        const auto& type = parameter.get_type();
+        const auto& name = parameter.get_name();
 
-    if (type == rclcpp::ParameterType::PARAMETER_DOUBLE) 
-    {
-      if (name == "read_rate") 
-      {
-        read_rate_ = parameter.as_double();
-        // Create timer with new read rate
-        RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
-        read_tmr_->cancel();
-        read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)), 
-                                  std::bind(&Driver::read, this));
-      } 
-      else if (name  == "publish_rate") 
-      {
-        publish_rate_ = parameter.as_double();
-        // Create timer with new publish rate
-        RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
-        publish_tmr_->cancel();
-        publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
-                                               std::bind(&Driver::proceed, this));
-      }
-      else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
-        camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
-      }
-      else if (name == "cv_cap_prop_brightness")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
-      }
-      else if (name == "cv_cap_prop_contrast")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
-      }
-      else if (name == "cv_cap_prop_saturation")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
-      }
-      else if (name == "cv_cap_prop_hue")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
-      }
-      else if (name == "cv_cap_prop_gain")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
-      }
-      else if (name == "cv_cap_prop_exposure")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-      }
-      else if (name == "cv_cap_prop_exposure")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
-      }
-      else if (name == "cv_cap_prop_auto_exposure")
-      {
-        camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
-      }
-    }
-    else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
-    {
-      if (name == "width")
-      {
-        width_ = parameter.as_int();
-        // update height to maintain aspect ratio
-        height_ = int(width_ / aspect_ratio_);
-        RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio", parameter.as_int(), height_);
-        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-        // so we need to reset the timer to update the resolution
-        update_resolution_tmr_->reset();
-      }
-      else if (name == "height")
-      {
-        height_ = parameter.as_int();
-        // update width to maintain aspect ratio
-        width_ = int(height_ * aspect_ratio_);
-        RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio", parameter.as_int(), width_);
-        // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
-        // so we need to reset the timer to update the resolution
-        update_resolution_tmr_->reset();
-      }
-    }
-    else if (type == rclcpp::ParameterType::PARAMETER_STRING)
-    {
-      if (name == "intrinsic_file")
-      {
-        camera_->loadCameraInfo();
-      }
-    }
-    else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
-    {
-      if (name == "roi_exposure")
-      {
-        roi_exposure_ = parameter.as_bool();
-        setup();
-      }
-      else if (name == "always_publish")
-      {
-        always_publish_ = parameter.as_bool();
-        if (cam_status_->data == PAUSED && always_publish_)
+        if (type == rclcpp::ParameterType::PARAMETER_DOUBLE)
         {
-          read_tmr_->reset();
-          publish_tmr_->reset();
-          cam_status_->data = ONLINE;
-          pub_cam_status_->publish(*cam_status_);
-          publish_diagnostic(ONLINE);
+            if (name == "read_rate")
+            {
+                read_rate_ = parameter.as_double();
+                // Create timer with new read rate
+                RCLCPP_WARN(get_logger(), "Setting new read rate to %f", read_rate_);
+                read_tmr_->cancel();
+                read_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / read_rate_)),
+                                                    std::bind(&Driver::read, this));
+            }
+            else if (name == "publish_rate")
+            {
+                publish_rate_ = parameter.as_double();
+                // Create timer with new publish rate
+                RCLCPP_WARN(get_logger(), "Setting new publish rate to %f", publish_rate_);
+                publish_tmr_->cancel();
+                publish_tmr_ = this->create_wall_timer(std::chrono::milliseconds(int(1000.0 / publish_rate_)),
+                                                       std::bind(&Driver::proceed, this));
+            }
+            else if (name == "cv_cap_prop_frame_width" || name == "cv_cap_prop_frame_height")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
+                camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
+            }
+            else if (name == "cv_cap_prop_brightness")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_BRIGHTNESS, "cv_cap_prop_brightness");
+            }
+            else if (name == "cv_cap_prop_contrast")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_CONTRAST, "cv_cap_prop_contrast");
+            }
+            else if (name == "cv_cap_prop_saturation")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_SATURATION, "cv_cap_prop_saturation");
+            }
+            else if (name == "cv_cap_prop_hue")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_HUE, "cv_cap_prop_hue");
+            }
+            else if (name == "cv_cap_prop_gain")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_GAIN, "cv_cap_prop_gain");
+            }
+            else if (name == "cv_cap_prop_exposure")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+            }
+            else if (name == "cv_cap_prop_exposure")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_EXPOSURE, "cv_cap_prop_exposure");
+            }
+            else if (name == "cv_cap_prop_auto_exposure")
+            {
+                camera_->setPropertyFromParam(cv::CAP_PROP_AUTO_EXPOSURE, "cv_cap_prop_auto_exposure");
+            }
         }
-      }
+        else if (type == rclcpp::ParameterType::PARAMETER_INTEGER)
+        {
+            if (name == "width")
+            {
+                width_ = parameter.as_int();
+                // update height to maintain aspect ratio
+                height_ = int(width_ / aspect_ratio_);
+                RCLCPP_INFO(get_logger(), "Setting new width to %ld and height to %d to maintain aspect ratio",
+                            parameter.as_int(), height_);
+                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+                // so we need to reset the timer to update the resolution
+                update_resolution_tmr_->reset();
+            }
+            else if (name == "height")
+            {
+                height_ = parameter.as_int();
+                // update width to maintain aspect ratio
+                width_ = int(height_ * aspect_ratio_);
+                RCLCPP_INFO(get_logger(), "Setting new height to %ld and width to %d to maintain aspect ratio",
+                            parameter.as_int(), width_);
+                // To set the underlying OpenCV parameter we cant set a parameter inside the setParameters callback
+                // so we need to reset the timer to update the resolution
+                update_resolution_tmr_->reset();
+            }
+        }
+        else if (type == rclcpp::ParameterType::PARAMETER_STRING)
+        {
+            if (name == "intrinsic_file")
+            {
+                camera_->loadCameraInfo();
+            }
+        }
+        else if (type == rclcpp::ParameterType::PARAMETER_BOOL)
+        {
+            if (name == "roi_exposure")
+            {
+                roi_exposure_ = parameter.as_bool();
+                setup();
+            }
+            else if (name == "always_publish")
+            {
+                always_publish_ = parameter.as_bool();
+                if (cam_status_->data == PAUSED && always_publish_)
+                {
+                    read_tmr_->reset();
+                    publish_tmr_->reset();
+                    cam_status_->data = ONLINE;
+                    pub_cam_status_->publish(*cam_status_);
+                    publish_diagnostic(ONLINE);
+                }
+            }
+        }
     }
-  }
     return result;
 }
 
 void Driver::RestartNodeCb(shared_ptr_request_id const, shared_ptr_trigger_request const,
-                          shared_ptr_trigger_response response)
+                           shared_ptr_trigger_response response)
 {
-  RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
-  reconnection_attempts_ = 0;
-  setup();
-  response->success = true;
-  response->message = "Camera setup will be restarted";
+    RCLCPP_WARN(get_logger(), "[%s] Restarting camera setup...", name_.c_str());
+    reconnection_attempts_ = 0;
+    setup();
+    response->success = true;
+    response->message = "Camera setup will be restarted";
 }
 
 void Driver::update_resolution()
 {
-  update_resolution_tmr_->cancel();
-  if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
-  {
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
-    camera_->rescaleCameraInfo(width_, height_);
-  }
-  if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
-  {
-    this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
-    camera_->rescaleCameraInfo(width_, height_);
-  }
+    update_resolution_tmr_->cancel();
+    if (width_ != camera_->getProperty(cv::CAP_PROP_FRAME_WIDTH) || width_ != (int)camera_->getInfo().width)
+    {
+        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_width", (double)width_));
+        camera_->rescaleCameraInfo(width_, height_);
+    }
+    if (height_ != camera_->getProperty(cv::CAP_PROP_FRAME_HEIGHT) || height_ != (int)camera_->getInfo().height)
+    {
+        this->set_parameter(rclcpp::Parameter("cv_cap_prop_frame_height", (double)height_));
+        camera_->rescaleCameraInfo(width_, height_);
+    }
 }
 
 void Driver::GrabFrameCb(shared_ptr_request_id const, shared_ptr_grab_frame_request const,
-                          shared_ptr_grab_frame_response response)
+                         shared_ptr_grab_frame_response response)
 {
-  // The sensor has a buffer so we need to grab several times to get the current image.
-  for (int i = 0; i <= 5; i++)
-  {
-    if (!camera_->grab())
+    // The sensor has a buffer so we need to grab several times to get the current image.
+    for (int i = 0; i <= 5; i++)
     {
-      response->success = false;
-      response->message = "Failed to grab frame from camera.";
-      return;
+        if (!camera_->grab())
+        {
+            response->success = false;
+            response->message = "Failed to grab frame from camera.";
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-  if (!camera_->capture(flip_vertical_, flip_horizontal_))
-  {
-    response->success = false;
-    response->message = "Failed to capture frame from camera.";
+    if (!camera_->capture(flip_vertical_, flip_horizontal_))
+    {
+        response->success = false;
+        response->message = "Failed to capture frame from camera.";
+        return;
+    }
+    response->frame = *camera_->getImageMsgPtr();
+    response->success = true;
+    response->message = "Successfully got frame!";
+    RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
     return;
-  }
-  response->frame = *camera_->getImageMsgPtr();
-  response->success = true;
-  response->message = "Successfully got frame!";
-  RCLCPP_INFO(get_logger(), "[%s] Sent requested frame...", name_.c_str());
-  return;
+}
+
+void Driver::isCameraFocusedCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
+                               shared_ptr_bool_response response)
+{
+    // Check if camera frame is available
+    if (camera_->getCvImage().empty())
+    {
+        response->success = false;
+        response->message = "Camera frame is empty";
+        return;
+    }
+
+    // Calculate image focus using Laplacian variance method
+    // Higher variance indicates more edges/details are in focus
+    cv::Mat frame = camera_->getCvImage();
+    cv::Mat gray, laplacian;
+    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);  // Convert to grayscale
+    cv::Laplacian(gray, laplacian, CV_64F);         // Apply Laplacian filter
+
+    cv::Scalar mean, stddev;
+    cv::meanStdDev(laplacian, mean, stddev);  // Calculate mean and standard deviation
+
+    double variance = stddev[0] * stddev[0];  // Calculate variance
+
+    // Threshold to determine if the camera is focused
+    // Note: In the original code, variance < threshold means unfocused
+    // But here we're checking if it's focused, so we invert the logic
+    bool is_focused = variance >= focus_threshold_;
+
+    response->success = is_focused;
+    response->message = "Variance: " + std::to_string(variance);  // Return the variance value in the message
+    return;
 }
 
 void Driver::PauseImageCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                            shared_ptr_bool_response response)
+                          shared_ptr_bool_response response)
 {
-  if (request->data && !always_publish_)
-  {
-    read_tmr_->cancel();
-    publish_tmr_->cancel();
-    cam_status_->data = PAUSED;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(PAUSED);
-    response->success = true;
-    response->message = "Camera read and pub paused";
-    return;
-  }
-  else if (cam_status_->data == PAUSED)
-  {
-    read_tmr_->reset();
-    publish_tmr_->reset();
-    cam_status_->data = ONLINE;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(ONLINE);
-    response->success = true;
-    response->message = "Camera read and pub resumed";
-    return;
-  }
+    if (request->data && !always_publish_)
+    {
+        read_tmr_->cancel();
+        publish_tmr_->cancel();
+        cam_status_->data = PAUSED;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(PAUSED);
+        response->success = true;
+        response->message = "Camera read and pub paused";
+        return;
+    }
+    else if (cam_status_->data == PAUSED)
+    {
+        read_tmr_->reset();
+        publish_tmr_->reset();
+        cam_status_->data = ONLINE;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(ONLINE);
+        response->success = true;
+        response->message = "Camera read and pub resumed";
+        return;
+    }
 }
 
-
 void Driver::ReleaseCamCb(shared_ptr_request_id const, shared_ptr_bool_request const request,
-                            shared_ptr_bool_response response)
+                          shared_ptr_bool_response response)
 {
-  if (request->data)
-  {
-    read_tmr_->cancel();
-    publish_tmr_->cancel();
-    camera_->close();
-    cam_status_->data = TURNED_OFF;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(TURNED_OFF);
-    response->success = true;
-    response->message = "Camera device released";
-    return;
-  }
-  else
-  {
-    setup();
-    read_tmr_->reset();
-    publish_tmr_->reset();
-    cam_status_->data = ONLINE;
-    pub_cam_status_->publish(*cam_status_);
-    publish_diagnostic(ONLINE);
-    response->success = true;
-    response->message = "Camera read and pub resumed";
-    return;
-  }
+    if (request->data)
+    {
+        read_tmr_->cancel();
+        publish_tmr_->cancel();
+        camera_->close();
+        cam_status_->data = TURNED_OFF;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(TURNED_OFF);
+        response->success = true;
+        response->message = "Camera device released";
+        return;
+    }
+    else
+    {
+        setup();
+        read_tmr_->reset();
+        publish_tmr_->reset();
+        cam_status_->data = ONLINE;
+        pub_cam_status_->publish(*cam_status_);
+        publish_diagnostic(ONLINE);
+        response->success = true;
+        response->message = "Camera read and pub resumed";
+        return;
+    }
 }
 void Driver::publish_diagnostic(Status status)
 {
-  auto message = diagnostic_msgs::msg::DiagnosticArray();
-  message.header.stamp = this->get_clock()->now();
-  auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
-  status_msg.name = "USB Camera Status";
-  status_msg.hardware_id = "/USB" + name_;
+    auto message = diagnostic_msgs::msg::DiagnosticArray();
+    message.header.stamp = this->get_clock()->now();
+    auto status_msg = diagnostic_msgs::msg::DiagnosticStatus();
+    status_msg.name = "USB Camera Status";
+    status_msg.hardware_id = "/USB" + name_;
 
-  switch (status) {
-    case ONLINE:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-        status_msg.message = "Camera is online";
-        break;
-    case DISCONNECTED:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Camera is disconnected";
-        break;
-    case LOST:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-        status_msg.message = "Camera lost";
-        break;
-    case READING_ERROR:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Reading error from camera";
-        break;
-    case PAUSED:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Camera is paused";
-        break;
-    case TURNED_OFF:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-        status_msg.message = "Camera is turned off";
-        break;
-    default:
-        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-        status_msg.message = "Unrecognized camera status";
-  }
+    switch (status)
+    {
+        case ONLINE:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+            status_msg.message = "Camera is online";
+            break;
+        case DISCONNECTED:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Camera is disconnected";
+            break;
+        case LOST:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+            status_msg.message = "Camera lost";
+            break;
+        case READING_ERROR:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Reading error from camera";
+            break;
+        case PAUSED:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Camera is paused";
+            break;
+        case TURNED_OFF:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+            status_msg.message = "Camera is turned off";
+            break;
+        default:
+            status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+            status_msg.message = "Unrecognized camera status";
+    }
 
-  message.status.push_back(status_msg);
-  pub_cam_diagnostic_->publish(message);
+    message.status.push_back(status_msg);
+    pub_cam_diagnostic_->publish(message);
 }
 
-Driver::~Driver()
-{
-}
+Driver::~Driver() {}
 
 }  // namespace cv_camera
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -49,6 +49,7 @@ void Driver::parameters_setup()
   param_manager_.addParameter<std::string>(frame_id_, "frame_id", "camera_id");
   param_manager_.addParameter(video_stream_recovery_time_, "video_stream_recovery_time", 2);
   param_manager_.addParameter(video_stream_recovery_tries_, "video_stream_recovery_tries", 10);
+  param_manager_.addParameter(focus_threshold_, "focus_threshold", 100.0);
 
   // Video capture parameters
   param_manager_.addParameter(width_, "width", 640);


### PR DESCRIPTION
### Summary:
This pull request introduces a new feature to the `cv_camera` package that allows for checking the focus of a camera using the Laplacian variance method. This method provides a quantitative measure of image sharpness, which can be used to determine if the camera is in focus.

### Key Changes:
- **Focus Check Implementation**: 
  - Added a method `isFocused()` that calculates the Laplacian variance of the current image frame to assess focus.
  - The method uses a parameter `focus_threshold` to determine if the image is considered focused. If the Laplacian variance is above this threshold, the image is deemed to be in focus.

- **Parameter Configuration**:
  - The focus threshold can be configured via the parameter server using the parameter name `focus_threshold`.
  - Default value for `focus_threshold` is set to `100.0`, but it can be adjusted based on specific requirements or camera characteristics.

### Usage:
1. **Parameter Setup**:
   - Ensure that the `focus_threshold` parameter is set in your ROS2 parameter server configuration. This can be done in a launch file or dynamically at runtime.
   - Example:
     ```yaml
     focus_threshold: 120.0
     ```

2. **Focus Check**:
   - Call the `isFocused()` method to check if the current camera frame is in focus.
   - The method will return `true` if the Laplacian variance is above the specified `focus_threshold`, indicating that the image is sharp and focused.

### Example:

```cpp
if (capture.isFocused()) {
    RCLCPP_INFO(node->get_logger(), "Camera is in focus.");
} else {
    RCLCPP_WARN(node->get_logger(), "Camera is out of focus.");
}
```